### PR TITLE
Remove the error case for `match_any`

### DIFF
--- a/src/chain/chain.rs
+++ b/src/chain/chain.rs
@@ -723,9 +723,7 @@ impl<H: HeaderStore> Chain<H> {
 
         #[cfg(not(feature = "filter-control"))]
         if !self.block_queue.contains(&filter_message.block_hash)
-            && filter
-                .contains_any(self.scripts.iter())
-                .map_err(CFilterSyncError::Filter)?
+            && filter.contains_any(self.scripts.iter())
         {
             // Add to the block queue
             self.block_queue.add(filter_message.block_hash);

--- a/src/filters/error.rs
+++ b/src/filters/error.rs
@@ -45,7 +45,6 @@ pub enum CFilterSyncError {
     UnrequestedStophash,
     UnknownFilterHash,
     MisalignedFilterHash,
-    Filter(FilterError),
 }
 
 impl core::fmt::Display for CFilterSyncError {
@@ -65,27 +64,8 @@ impl core::fmt::Display for CFilterSyncError {
                 f,
                 "the filter hash from our header chain and this filter hash do not match."
             ),
-            CFilterSyncError::Filter(_) => write!(
-                f,
-                "the filter experienced an IO error checking for Script inclusions."
-            ),
         }
     }
 }
 
 impl_sourceless_error!(CFilterSyncError);
-
-#[derive(Debug)]
-pub enum FilterError {
-    IORead,
-}
-
-impl core::fmt::Display for FilterError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            FilterError::IORead => write!(f, "unable to read from the filter contents buffer."),
-        }
-    }
-}
-
-impl_sourceless_error!(FilterError);

--- a/src/filters/mod.rs
+++ b/src/filters/mod.rs
@@ -10,8 +10,6 @@ pub(crate) mod filter_chain;
 use bitcoin::hashes::{sha256d, Hash};
 use bitcoin::{bip158::BlockFilter, BlockHash, FilterHash, ScriptBuf};
 
-use error::FilterError;
-
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct Filter {
     filter_hash: FilterHash,
@@ -40,12 +38,9 @@ impl Filter {
         &self.block_hash
     }
 
-    pub fn contains_any<'a>(
-        &'a mut self,
-        scripts: impl Iterator<Item = &'a ScriptBuf>,
-    ) -> Result<bool, FilterError> {
+    pub fn contains_any<'a>(&'a mut self, scripts: impl Iterator<Item = &'a ScriptBuf>) -> bool {
         self.block_filter
             .match_any(&self.block_hash, scripts.map(|script| script.to_bytes()))
-            .map_err(|_| FilterError::IORead)
+            .expect("&[u8] reader is infalliable")
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -229,9 +229,7 @@ impl IndexedFilter {
 
     /// Does the filter contain a positive match for any of the provided scripts
     pub fn contains_any<'a>(&'a mut self, scripts: impl Iterator<Item = &'a ScriptBuf>) -> bool {
-        self.filter
-            .contains_any(scripts)
-            .expect("vec reader is infallible")
+        self.filter.contains_any(scripts)
     }
 }
 

--- a/src/node.rs
+++ b/src/node.rs
@@ -24,7 +24,7 @@ use crate::{
     },
     db::traits::{HeaderStore, PeerStore},
     error::FetchHeaderError,
-    filters::{cfheader_chain::AppendAttempt, error::CFilterSyncError},
+    filters::cfheader_chain::AppendAttempt,
     network::{peer_map::PeerMap, LastBlockMonitor, PeerId, PeerTimeoutConfig},
     FilterSyncPolicy, NodeState, RejectPayload, TxBroadcastPolicy,
 };
@@ -624,14 +624,9 @@ impl<H: HeaderStore, P: PeerStore> Node<H, P> {
                 self.dialog.send_warning(Warning::UnexpectedSyncError {
                     warning: format!("Compact filter syncing encountered an error: {}", e),
                 });
-                match e {
-                    CFilterSyncError::Filter(_) => Some(MainThreadMessage::Disconnect),
-                    _ => {
-                        let mut lock = self.peer_map.lock().await;
-                        lock.ban(peer_id).await;
-                        Some(MainThreadMessage::Disconnect)
-                    }
-                }
+                let mut lock = self.peer_map.lock().await;
+                lock.ban(peer_id).await;
+                Some(MainThreadMessage::Disconnect)
             }
         }
     }


### PR DESCRIPTION
As of Rust lang `1.0.0` the `&[u8]` type does not include any error cases in the `Read::read` function (instead there are panics). The bip158 module of `rust-bitcoin` involves a lot of error propagation, but ultimately the fallible function is `Read::read` on a slice. Removing the error case allows for a cleaner API both internally and externally for future silent payments users.

Read trait invocation: https://docs.rs/bitcoin/latest/src/bitcoin/bip158.rs.html#455
The buffer: https://docs.rs/bitcoin/latest/src/bitcoin/bip158.rs.html#470
Read implemented for `&[u8]`: https://doc.rust-lang.org/src/std/io/impls.rs.html#298-403

Note this is the same message in the commit so there is a reference.