### PR TITLE
build(ci): migrate sync task to a weekly scheduled workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,13 +54,6 @@ jobs:
       - uses: extractions/setup-just@v3
       - uses: actions-rust-lang/setup-rust-toolchain@v1
       - run: just test msrv
-  sync:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: extractions/setup-just@v3
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
-      - run: just test sync
   integration:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/weekly-sync-test.yml
+++ b/.github/workflows/weekly-sync-test.yml
@@ -1,0 +1,17 @@
+name: Weekly Sync Test
+
+on:
+  # Allows manual triggering.
+  workflow_dispatch:  
+  schedule:
+   # Run at midnight on Sundays.
+   - cron: "0 0 * * 0" 
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: extractions/setup-just@v3
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - run: just test sync

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -31,12 +31,12 @@ pub enum Info {
 impl core::fmt::Display for Info {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
-            Info::StateChange(s) => write!(f, "{}", s),
-            Info::TxSent(txid) => write!(f, "Transaction sent: {}", txid),
+            Info::StateChange(s) => write!(f, "{s}"),
+            Info::TxSent(txid) => write!(f, "Transaction sent: {txid}"),
             Info::ConnectionsMet => write!(f, "Required connections met"),
             Info::Progress(p) => {
                 let progress_percent = p.percentage_complete();
-                write!(f, "Percent complete: {}", progress_percent)
+                write!(f, "Percent complete: {progress_percent}")
             }
         }
     }
@@ -271,8 +271,7 @@ impl core::fmt::Display for Warning {
             } => {
                 write!(
                     f,
-                    "Looking for connections to peers. Connected: {}, Required: {}",
-                    connected, required
+                    "Looking for connections to peers. Connected: {connected}, Required: {required}"
                 )
             }
             Warning::InvalidStartHeight => write!(
@@ -295,12 +294,12 @@ impl core::fmt::Display for Warning {
                 write!(f, "A transaction got rejected: TXID {}", payload.txid)
             }
             Warning::FailedPersistence { warning } => {
-                write!(f, "A database failed to persist some data: {}", warning)
+                write!(f, "A database failed to persist some data: {warning}")
             }
             Warning::EvaluatingFork => write!(f, "Peer sent us a potential fork."),
             Warning::EmptyPeerDatabase => write!(f, "The peer database has no values."),
             Warning::UnexpectedSyncError { warning } => {
-                write!(f, "Error handling a P2P message: {}", warning)
+                write!(f, "Error handling a P2P message: {warning}")
             }
             Warning::CorruptedHeaders => {
                 write!(f, "The headers in the database do not link together.")

--- a/src/node.rs
+++ b/src/node.rs
@@ -571,7 +571,7 @@ impl<H: HeaderStore, P: PeerStore> Node<H, P> {
                 }
                 _ => {
                     self.dialog.send_warning(Warning::UnexpectedSyncError {
-                        warning: format!("Unexpected header syncing error: {}", e),
+                        warning: format!("Unexpected header syncing error: {e}"),
                     });
                     let mut lock = self.peer_map.lock().await;
                     lock.ban(peer_id).await;
@@ -602,7 +602,7 @@ impl<H: HeaderStore, P: PeerStore> Node<H, P> {
             },
             Err(e) => {
                 self.dialog.send_warning(Warning::UnexpectedSyncError {
-                    warning: format!("Compact filter header syncing encountered an error: {}", e),
+                    warning: format!("Compact filter header syncing encountered an error: {e}"),
                 });
                 let mut lock = self.peer_map.lock().await;
                 lock.ban(peer_id).await;
@@ -618,7 +618,7 @@ impl<H: HeaderStore, P: PeerStore> Node<H, P> {
             Ok(potential_message) => potential_message.map(MainThreadMessage::GetFilters),
             Err(e) => {
                 self.dialog.send_warning(Warning::UnexpectedSyncError {
-                    warning: format!("Compact filter syncing encountered an error: {}", e),
+                    warning: format!("Compact filter syncing encountered an error: {e}"),
                 });
                 match e {
                     CFilterSyncError::Filter(_) => Some(MainThreadMessage::Disconnect),
@@ -637,7 +637,7 @@ impl<H: HeaderStore, P: PeerStore> Node<H, P> {
         let mut chain = self.chain.lock().await;
         if let Err(e) = chain.check_send_block(block).await {
             self.dialog.send_warning(Warning::UnexpectedSyncError {
-                warning: format!("Unexpected block scanning error: {}", e),
+                warning: format!("Unexpected block scanning error: {e}"),
             });
             let mut lock = self.peer_map.lock().await;
             lock.ban(peer_id).await;


### PR DESCRIPTION
The signet sync test is valuable, but a liitle heavy and flakey for the CI workflow.

I am pretty sure a failure auto-notifies contributors.

Closes #347 