### PR TITLE
Use an extension trait to define what a `Height` is

### DIFF
--- a/src/chain/chain.rs
+++ b/src/chain/chain.rs
@@ -419,7 +419,7 @@ impl<H: HeaderStore> Chain<H> {
                     break;
                 }
                 None => {
-                    last_unchecked_cfheader = data.height.to_u32();
+                    last_unchecked_cfheader = data.height;
                 }
             }
         }
@@ -519,7 +519,7 @@ impl<H: HeaderStore> Chain<H> {
             if block_data.filter_checked {
                 break;
             }
-            last_unchecked_filter = block_data.height.to_u32();
+            last_unchecked_filter = block_data.height;
         }
         let stop_hash_index = last_unchecked_filter + FILTER_BATCH_SIZE;
         let stop_hash = self


### PR DESCRIPTION
Instead of trying to figure out if a height should be `u32`, `u64` or `bitcoin::absolute::Height`, all the `graph::Height` wrapper defines is some safety rails. This is typically the use for extension traits. Instead of trying to propagate a new type around the crate, this trait can be used to define useful methods when we want to consider a `u32` as a height. In particular, we mostly want to know if a height is a difficulty adjustment, or when the last difficulty adjustment was. 

Other users could _maybe_ be interested in using this for their application logic? I have it marked as `pub` for now.