### PR TITLE
Load relevant block headers into memory at startup

### DIFF
--- a/src/chain/checkpoints.rs
+++ b/src/chain/checkpoints.rs
@@ -625,10 +625,6 @@ impl HeaderCheckpoints {
         self.checkpoints.pop_front();
     }
 
-    pub fn is_exhausted(&self) -> bool {
-        self.checkpoints.is_empty()
-    }
-
     pub fn last(&self) -> HeaderCheckpoint {
         self.last
     }

--- a/src/node.rs
+++ b/src/node.rs
@@ -470,7 +470,7 @@ impl<H: HeaderStore, P: PeerStore> Node<H, P> {
     async fn next_stateful_message(&self, chain: &mut Chain<H>) -> Option<MainThreadMessage> {
         if !chain.is_synced().await {
             let headers = GetHeaderConfig {
-                locators: chain.locators().await,
+                locators: chain.header_chain.locators(),
                 stop_hash: None,
             };
             return Some(MainThreadMessage::GetHeaders(headers));
@@ -534,9 +534,9 @@ impl<H: HeaderStore, P: PeerStore> Node<H, P> {
             crate::info!(self.dialog, Info::ConnectionsMet);
         }
         // Even if we start the node as caught up in terms of height, we need to check for reorgs. So we can send this unconditionally.
-        let mut chain = self.chain.lock().await;
+        let chain = self.chain.lock().await;
         let next_headers = GetHeaderConfig {
-            locators: chain.locators().await,
+            locators: chain.header_chain.locators(),
             stop_hash: None,
         };
         Ok(MainThreadMessage::GetHeaders(next_headers))
@@ -697,7 +697,7 @@ impl<H: HeaderStore, P: PeerStore> Node<H, P> {
                     crate::info!(self.dialog, Info::StateChange(NodeState::Behind));
                     *state = NodeState::Behind;
                     let next_headers = GetHeaderConfig {
-                        locators: chain.locators().await,
+                        locators: chain.header_chain.locators(),
                         stop_hash: None,
                     };
                     chain.clear_compact_filter_queue();


### PR DESCRIPTION
Based on #353 to show where I am going with that PR.

Currently there is a strange bit of code to handle the case of an unknown previous hash when accepting a block header. We check the database if the hash is present there, and then reinitialize the `BlockTree` from that header if present in the database. Because the `BlockTree` holds every header in memory now, a better approach is to just load in headers that are 7 blocks in the past in at the start. Better yet, we can also load in the header necessary to compute the next difficulty adjustment. In this PR, I attempt to load as far back in the history as possible to gracefully handle reorganizations and difficulty adjustments. 

One caveat is that this would be ignoring where the user requested to start their scan from. Re-emitting blocks is [forbidden in some cases](https://docs.rs/lightning/0.1.2/src/lightning/ln/channelmanager.rs.html#10835) in higher level LN implementations, so the start height must be adhered to. To compensate for this, I added an `assumed_checked_to` method on `BlockTree`, that marks each filter in the chain loaded from disk as checked, up to the height the user requested. Note that, because the filter messages are constructed by traversing the block tree, reorganizations will still check filters below this height if necessary.

This removes the need to do any further loading after the initialization in `Node::run`