### PR TITLE
fix(network): drop dynamic dispatch on read path

### DIFF
--- a/src/network/parsers.rs
+++ b/src/network/parsers.rs
@@ -5,105 +5,73 @@ use bitcoin::p2p::message::RawNetworkMessage;
 use bitcoin::Network;
 use tokio::io::AsyncReadExt;
 
-use crate::prelude::FutureResult;
-
 use super::error::PeerReadError;
 use super::V1Header;
-use super::{traits::MessageParser, StreamReader};
 
 const MAX_MESSAGE_BYTES: u32 = 1024 * 1024 * 32;
 
-pub(crate) struct V1MessageParser {
-    stream: StreamReader,
-    network: Network,
+pub(crate) enum MessageParser<R: AsyncReadExt + Send + Sync + Unpin> {
+    V2(R, PacketReader),
+    V1(R, Network),
 }
 
-impl V1MessageParser {
-    pub(crate) fn new(stream: StreamReader, network: Network) -> Self {
-        Self { stream, network }
-    }
-
-    async fn do_read_message(&mut self) -> Result<Option<NetworkMessage>, PeerReadError> {
-        let mut message_buf = vec![0_u8; 24];
-        let _ = self
-            .stream
-            .read_exact(&mut message_buf)
-            .await
-            .map_err(|_| PeerReadError::ReadBuffer)?;
-        let header: V1Header = deserialize_partial(&message_buf)
-            .map_err(|_| PeerReadError::Deserialization)?
-            .0;
-        // Nonsense for our network
-        if header.magic != self.network.magic() {
-            return Err(PeerReadError::Deserialization);
-        }
-        // Message is too long
-        if header.length > MAX_MESSAGE_BYTES {
-            return Err(PeerReadError::Deserialization);
-        }
-        let mut contents_buf = vec![0_u8; header.length as usize];
-        let _ = self
-            .stream
-            .read_exact(&mut contents_buf)
-            .await
-            .map_err(|_| PeerReadError::ReadBuffer)?;
-        message_buf.extend_from_slice(&contents_buf);
-        let message: RawNetworkMessage =
-            deserialize(&message_buf).map_err(|_| PeerReadError::Deserialization)?;
-        Ok(Some(message.into_payload()))
-    }
-}
-
-impl MessageParser for V1MessageParser {
-    fn read_message(&mut self) -> FutureResult<Option<NetworkMessage>, PeerReadError> {
-        Box::pin(self.do_read_message())
-    }
-}
-
-pub(crate) struct V2MessageParser {
-    stream: StreamReader,
-    decryptor: PacketReader,
-}
-
-impl V2MessageParser {
-    pub(crate) fn new(stream: StreamReader, decryptor: PacketReader) -> Self {
-        Self { stream, decryptor }
-    }
-
-    async fn do_read_message(&mut self) -> Result<Option<NetworkMessage>, PeerReadError> {
-        let mut len_buf = [0; 3];
-        let _ = self
-            .stream
-            .read_exact(&mut len_buf)
-            .await
-            .map_err(|_| PeerReadError::ReadBuffer)?;
-        let message_len = self.decryptor.decypt_len(len_buf);
-        if message_len > MAX_MESSAGE_BYTES as usize {
-            return Err(PeerReadError::TooManyMessages);
-        }
-        let mut response_message = vec![0; message_len];
-        let _ = self
-            .stream
-            .read_exact(&mut response_message)
-            .await
-            .map_err(|_| PeerReadError::ReadBuffer)?;
-        let msg = self
-            .decryptor
-            .decrypt_payload(&response_message, None)
-            .map_err(|_| PeerReadError::DecryptionFailed)?;
-        match msg.packet_type() {
-            PacketType::Genuine => {
-                let parsed = bip324::serde::deserialize(msg.contents())
-                    .map_err(|_| PeerReadError::Deserialization)?;
-                Ok(Some(parsed))
+impl<R: AsyncReadExt + Send + Sync + Unpin> MessageParser<R> {
+    pub async fn read_message(&mut self) -> Result<Option<NetworkMessage>, PeerReadError> {
+        match self {
+            MessageParser::V2(stream, decryptor) => {
+                let mut len_buf = [0; 3];
+                let _ = stream
+                    .read_exact(&mut len_buf)
+                    .await
+                    .map_err(|_| PeerReadError::ReadBuffer)?;
+                let message_len = decryptor.decypt_len(len_buf);
+                if message_len > MAX_MESSAGE_BYTES as usize {
+                    return Err(PeerReadError::TooManyMessages);
+                }
+                let mut response_message = vec![0; message_len];
+                let _ = stream
+                    .read_exact(&mut response_message)
+                    .await
+                    .map_err(|_| PeerReadError::ReadBuffer)?;
+                let msg = decryptor
+                    .decrypt_payload(&response_message, None)
+                    .map_err(|_| PeerReadError::DecryptionFailed)?;
+                match msg.packet_type() {
+                    PacketType::Genuine => {
+                        let parsed = bip324::serde::deserialize(msg.contents())
+                            .map_err(|_| PeerReadError::Deserialization)?;
+                        Ok(Some(parsed))
+                    }
+                    PacketType::Decoy => Ok(None),
+                }
             }
-            PacketType::Decoy => Ok(None),
+            MessageParser::V1(stream, network) => {
+                let mut message_buf = vec![0_u8; 24];
+                let _ = stream
+                    .read_exact(&mut message_buf)
+                    .await
+                    .map_err(|_| PeerReadError::ReadBuffer)?;
+                let header: V1Header = deserialize_partial(&message_buf)
+                    .map_err(|_| PeerReadError::Deserialization)?
+                    .0;
+                // Nonsense for our network
+                if header.magic != network.magic() {
+                    return Err(PeerReadError::Deserialization);
+                }
+                // Message is too long
+                if header.length > MAX_MESSAGE_BYTES {
+                    return Err(PeerReadError::Deserialization);
+                }
+                let mut contents_buf = vec![0_u8; header.length as usize];
+                let _ = stream
+                    .read_exact(&mut contents_buf)
+                    .await
+                    .map_err(|_| PeerReadError::ReadBuffer)?;
+                message_buf.extend_from_slice(&contents_buf);
+                let message: RawNetworkMessage =
+                    deserialize(&message_buf).map_err(|_| PeerReadError::Deserialization)?;
+                Ok(Some(message.into_payload()))
+            }
         }
-    }
-}
-
-impl MessageParser for V2MessageParser {
-    fn read_message(&mut self) -> FutureResult<Option<NetworkMessage>, PeerReadError> {
-        Box::pin(self.do_read_message())
     }
 }

--- a/src/network/peer_map.rs
+++ b/src/network/peer_map.rs
@@ -171,11 +171,11 @@ impl<P: PeerStore> PeerMap<P> {
             self.dialog,
             format!("Connecting to {:?}:{}", loaded_peer.addr, loaded_peer.port)
         );
-        let (reader, writer) = self
+        let connection = self
             .connector
             .connect(loaded_peer.addr.clone(), loaded_peer.port)
             .await?;
-        let handle = tokio::spawn(async move { peer.run(reader, writer).await });
+        let handle = tokio::spawn(async move { peer.run(connection).await });
         self.map.insert(
             self.current_id,
             ManagedPeer {

--- a/src/network/socks.rs
+++ b/src/network/socks.rs
@@ -11,8 +11,6 @@ use tokio::{
     net::TcpStream,
 };
 
-use crate::network::{StreamReader, StreamWriter};
-
 use super::error::Socks5Error;
 
 const CONNECTION_TIMEOUT: u64 = 2;
@@ -29,7 +27,7 @@ pub(crate) async fn create_socks5(
     proxy: SocketAddr,
     ip_addr: IpAddr,
     port: u16,
-) -> Result<(StreamReader, StreamWriter), Socks5Error> {
+) -> Result<TcpStream, Socks5Error> {
     // Connect to the proxy, likely a local Tor daemon.
     let timeout = tokio::time::timeout(
         Duration::from_secs(CONNECTION_TIMEOUT),
@@ -88,7 +86,7 @@ pub(crate) async fn create_socks5(
         }
         _ => return Err(Socks5Error::ConnectionFailed),
     }
+
     // Proxy handshake is complete, the TCP reader/writer can be returned
-    let (reader, writer) = tcp_stream.into_split();
-    Ok((Box::new(reader), Box::new(writer)))
+    Ok(tcp_stream)
 }

--- a/src/network/traits.rs
+++ b/src/network/traits.rs
@@ -1,14 +1,11 @@
 use bitcoin::{
-    p2p::{
-        message::NetworkMessage,
-        message_filter::{GetCFHeaders, GetCFilters},
-    },
+    p2p::message_filter::{GetCFHeaders, GetCFilters},
     BlockHash, Transaction, Wtxid,
 };
 
-use crate::{channel_messages::GetBlockConfig, prelude::FutureResult};
+use crate::channel_messages::GetBlockConfig;
 
-use super::error::{PeerError, PeerReadError};
+use super::error::PeerError;
 
 // Responsible for serializing messages to write over the wire, either encrypted or plaintext.
 pub(crate) trait MessageGenerator: Send + Sync {
@@ -39,9 +36,4 @@ pub(crate) trait MessageGenerator: Send + Sync {
     fn announce_transaction(&mut self, wtxid: Wtxid) -> Result<Vec<u8>, PeerError>;
 
     fn broadcast_transaction(&mut self, transaction: Transaction) -> Result<Vec<u8>, PeerError>;
-}
-
-// Responsible for parsing plaintext or encrypted messages off of the  wire.
-pub(crate) trait MessageParser: Send + Sync {
-    fn read_message(&mut self) -> FutureResult<Option<NetworkMessage>, PeerReadError>;
 }


### PR DESCRIPTION
Breaking this refactor up into separate steps since it is getting pretty hairy. The overall goal is to get rid of dynamic dispatch in the network module. Starting here with the read path. The write path can be done in a separate patch since its impl is slightly different. I have some ideas for general clean up as well (e.g. make use of the lower level bip324 types), but going to save those till after to keep the changesets clearer.

* Dropping the Stream{Reader/Writer} types to avoid dynamic dispatch on the message read path.
* Have opted to pass around a concrete TcpStream more often and only splitting it when needed.
* The read implementations are now an enum avoiding any major modifications for now.