### PR TITLE
Improve the peer timeout API

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -165,7 +165,7 @@ impl NodeBuilder {
     ///
     /// If none is provided, a timeout of 5 seconds will be used.
     pub fn response_timeout(mut self, response_timeout: Duration) -> Self {
-        self.config.response_timeout = response_timeout;
+        self.config.peer_timeout_config.response_timeout = response_timeout;
         self
     }
 
@@ -180,7 +180,7 @@ impl NodeBuilder {
     ///
     /// If none is provided, a maximum connection time of two hours will be used.
     pub fn maximum_connection_time(mut self, max_connection_time: Duration) -> Self {
-        self.config.max_connection_time = max_connection_time;
+        self.config.peer_timeout_config.max_connection_time = max_connection_time;
         self
     }
 

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -44,7 +44,7 @@ const MAX_PEERS: u8 = 15;
 ///     .unwrap();
 /// ```
 ///
-/// Or, more pratically, known Bitcoin scripts to monitor for may be added
+/// Or, more practically, known Bitcoin scripts to monitor for may be added
 /// as the node is built.
 ///
 /// ```rust
@@ -155,6 +155,15 @@ impl NodeBuilder {
         self
     }
 
+    /// Set the time a peer has to complete the initial TCP handshake. Even on unstable
+    /// connections this may be fast.
+    ///
+    /// If none is provided, a timeout of two seconds will be used.
+    pub fn handshake_timeout(mut self, handshake_timeout: impl Into<Duration>) -> Self {
+        self.config.peer_timeout_config.handshake_timeout = handshake_timeout.into();
+        self
+    }
+
     /// Set the time duration a peer has to respond to a message from the local node.
     ///
     /// ## Note
@@ -164,8 +173,8 @@ impl NodeBuilder {
     /// nodes may be slower to respond while processing blocks and transactions.
     ///
     /// If none is provided, a timeout of 5 seconds will be used.
-    pub fn response_timeout(mut self, response_timeout: Duration) -> Self {
-        self.config.peer_timeout_config.response_timeout = response_timeout;
+    pub fn response_timeout(mut self, response_timeout: impl Into<Duration>) -> Self {
+        self.config.peer_timeout_config.response_timeout = response_timeout.into();
         self
     }
 
@@ -179,8 +188,8 @@ impl NodeBuilder {
     /// new and reliable peers faster, so the maximum connection time may be shorter.
     ///
     /// If none is provided, a maximum connection time of two hours will be used.
-    pub fn maximum_connection_time(mut self, max_connection_time: Duration) -> Self {
-        self.config.peer_timeout_config.max_connection_time = max_connection_time;
+    pub fn maximum_connection_time(mut self, max_connection_time: impl Into<Duration>) -> Self {
+        self.config.peer_timeout_config.max_connection_time = max_connection_time.into();
         self
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,17 +1,14 @@
-use std::{collections::HashSet, path::PathBuf, time::Duration};
+use std::{collections::HashSet, path::PathBuf};
 
 use bitcoin::ScriptBuf;
 
 use crate::{
     chain::checkpoints::HeaderCheckpoint,
     network::{dns::DnsResolver, ConnectionType},
-    FilterSyncPolicy, LogLevel, PeerStoreSizeConfig, TrustedPeer,
+    FilterSyncPolicy, LogLevel, PeerStoreSizeConfig, PeerTimeoutConfig, TrustedPeer,
 };
 
 const REQUIRED_PEERS: u8 = 1;
-const TIMEOUT_SECS: u64 = 5;
-//                    sec  min  hour
-const TWO_HOUR: u64 = 60 * 60 * 2;
 
 pub(crate) struct NodeConfig {
     pub required_peers: u8,
@@ -22,8 +19,7 @@ pub(crate) struct NodeConfig {
     pub header_checkpoint: Option<HeaderCheckpoint>,
     pub connection_type: ConnectionType,
     pub target_peer_size: PeerStoreSizeConfig,
-    pub response_timeout: Duration,
-    pub max_connection_time: Duration,
+    pub peer_timeout_config: PeerTimeoutConfig,
     pub filter_sync_policy: FilterSyncPolicy,
     pub log_level: LogLevel,
 }
@@ -39,8 +35,7 @@ impl Default for NodeConfig {
             header_checkpoint: Default::default(),
             connection_type: Default::default(),
             target_peer_size: PeerStoreSizeConfig::default(),
-            response_timeout: Duration::from_secs(TIMEOUT_SECS),
-            max_connection_time: Duration::from_secs(TWO_HOUR),
+            peer_timeout_config: PeerTimeoutConfig::default(),
             filter_sync_policy: Default::default(),
             log_level: Default::default(),
         }

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -31,6 +31,9 @@ pub const KYOTO_VERSION: &str = "0.10.0";
 pub const RUST_BITCOIN_VERSION: &str = "0.32.4";
 
 const THIRTY_MINS: u64 = 60 * 30;
+const TIMEOUT_SECS: u64 = 5;
+//                    sec  min  hour
+const TWO_HOUR: u64 = 60 * 60 * 2;
 const CONNECTION_TIMEOUT: u64 = 2;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -69,6 +72,15 @@ impl PeerTimeoutConfig {
         Self {
             response_timeout,
             max_connection_time,
+        }
+    }
+}
+
+impl Default for PeerTimeoutConfig {
+    fn default() -> Self {
+        Self {
+            response_timeout: Duration::from_secs(TIMEOUT_SECS),
+            max_connection_time: Duration::from_secs(TWO_HOUR),
         }
     }
 }

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -31,10 +31,10 @@ pub const KYOTO_VERSION: &str = "0.10.0";
 pub const RUST_BITCOIN_VERSION: &str = "0.32.4";
 
 const THIRTY_MINS: u64 = 60 * 30;
-const TIMEOUT_SECS: u64 = 5;
+const MESSAGE_TIMEOUT_SECS: u64 = 5;
 //                    sec  min  hour
 const TWO_HOUR: u64 = 60 * 60 * 2;
-const CONNECTION_TIMEOUT: u64 = 2;
+const TCP_CONNECTION_TIMEOUT: u64 = 2;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub(crate) struct PeerId(pub(crate) u32);
@@ -64,14 +64,21 @@ pub struct PeerTimeoutConfig {
     pub(crate) response_timeout: Duration,
     /// Maximum time to maintain a connection with a peer
     pub(crate) max_connection_time: Duration,
+    /// How much time does the peer have to make the initial TCP handshake
+    pub(crate) handshake_timeout: Duration,
 }
 
 impl PeerTimeoutConfig {
     /// Create a new peer timeout configuration
-    pub fn new(response_timeout: Duration, max_connection_time: Duration) -> Self {
+    pub fn new(
+        response_timeout: Duration,
+        max_connection_time: Duration,
+        handshake_timeout: Duration,
+    ) -> Self {
         Self {
             response_timeout,
             max_connection_time,
+            handshake_timeout,
         }
     }
 }
@@ -79,8 +86,9 @@ impl PeerTimeoutConfig {
 impl Default for PeerTimeoutConfig {
     fn default() -> Self {
         Self {
-            response_timeout: Duration::from_secs(TIMEOUT_SECS),
+            response_timeout: Duration::from_secs(MESSAGE_TIMEOUT_SECS),
             max_connection_time: Duration::from_secs(TWO_HOUR),
+            handshake_timeout: Duration::from_secs(TCP_CONNECTION_TIMEOUT),
         }
     }
 }
@@ -121,7 +129,12 @@ impl ConnectionType {
         }
     }
 
-    pub(crate) async fn connect(&self, addr: AddrV2, port: u16) -> Result<TcpStream, PeerError> {
+    pub(crate) async fn connect(
+        &self,
+        addr: AddrV2,
+        port: u16,
+        handshake_timeout: Duration,
+    ) -> Result<TcpStream, PeerError> {
         let socket_addr = match addr {
             AddrV2::Ipv4(ip) => IpAddr::V4(ip),
             AddrV2::Ipv6(ip) => IpAddr::V6(ip),
@@ -130,7 +143,7 @@ impl ConnectionType {
         match &self {
             Self::ClearNet => {
                 let timeout = tokio::time::timeout(
-                    Duration::from_secs(CONNECTION_TIMEOUT),
+                    handshake_timeout,
                     TcpStream::connect((socket_addr, port)),
                 )
                 .await
@@ -140,7 +153,7 @@ impl ConnectionType {
             }
             Self::Socks5Proxy(proxy) => {
                 let socks5_timeout = tokio::time::timeout(
-                    Duration::from_secs(CONNECTION_TIMEOUT),
+                    handshake_timeout,
                     create_socks5(*proxy, socket_addr, port),
                 )
                 .await

--- a/src/network/peer_map.rs
+++ b/src/network/peer_map.rs
@@ -173,7 +173,11 @@ impl<P: PeerStore> PeerMap<P> {
         );
         let connection = self
             .connector
-            .connect(loaded_peer.addr.clone(), loaded_peer.port)
+            .connect(
+                loaded_peer.addr.clone(),
+                loaded_peer.port,
+                self.timeout_config.handshake_timeout,
+            )
             .await?;
         let handle = tokio::spawn(async move { peer.run(connection).await });
         self.map.insert(
@@ -376,7 +380,7 @@ impl<P: PeerStore> PeerMap<P> {
     async fn bootstrap(&mut self) -> Result<(), PeerManagerError<P::Error>> {
         use crate::network::dns::Dns;
         use std::net::IpAddr;
-        crate::log!(self.dialog, "Bootstraping peers with DNS");
+        crate::log!(self.dialog, "Bootstrapping peers with DNS");
         let mut db_lock = self.db.lock().await;
         let new_peers = Dns::new(self.network, self.dns_resolver)
             .bootstrap()

--- a/src/node.rs
+++ b/src/node.rs
@@ -27,7 +27,7 @@ use crate::{
     },
     db::traits::{HeaderStore, PeerStore},
     error::FetchHeaderError,
-    network::{peer_map::PeerMap, LastBlockMonitor, PeerId, PeerTimeoutConfig},
+    network::{peer_map::PeerMap, LastBlockMonitor, PeerId},
     FilterSyncPolicy, NodeState, RejectPayload, TxBroadcastPolicy,
 };
 
@@ -79,12 +79,10 @@ impl<H: HeaderStore, P: PeerStore> Node<H, P> {
             header_checkpoint,
             connection_type,
             target_peer_size,
-            response_timeout,
-            max_connection_time,
+            peer_timeout_config,
             filter_sync_policy,
             log_level,
         } = config;
-        let timeout_config = PeerTimeoutConfig::new(response_timeout, max_connection_time);
         // Set up a communication channel between the node and client
         let (log_tx, log_rx) = mpsc::channel::<String>(32);
         let (info_tx, info_rx) = mpsc::channel::<Info>(32);
@@ -107,7 +105,7 @@ impl<H: HeaderStore, P: PeerStore> Node<H, P> {
             Arc::clone(&dialog),
             connection_type,
             target_peer_size,
-            timeout_config,
+            peer_timeout_config,
             Arc::clone(&height_monitor),
             dns_resolver,
         )));


### PR DESCRIPTION
First commit:
- Consolidate the separate fields of the config that determined timeout values into the `PeerTimeoutConfig`, which already existed. Moves a couple constants to the `network` module so `PeerTimeoutConfig` can implement `Default`.

Second commit:
- Uses the `impl Into<Duration>` syntax, because a user should be free to swap `std::time::Duration` and `tokio::time::Duration`
- Adds a new handshake timeout field to `PeerTimeoutConfig`, which is passed to the `connect` method as an argument.