### PR TITLE
Pre-release cleaup

### DIFF
--- a/src/chain/chain.rs
+++ b/src/chain/chain.rs
@@ -640,7 +640,7 @@ impl<H: HeaderStore> Chain<H> {
             Info::Progress(Progress::new(
                 self.header_chain.total_filter_headers_synced(),
                 self.header_chain.total_filters_synced(),
-                self.header_chain.internally_cached_headers() as u32
+                self.header_chain.internal_chain_len() as u32
             ))
         );
         crate::log!(
@@ -654,9 +654,9 @@ impl<H: HeaderStore> Chain<H> {
                     .max()
                     .unwrap_or(self.header_chain.height()),
                 self.header_chain.total_filter_headers_synced(),
-                self.header_chain.internally_cached_headers() as u32,
+                self.header_chain.internal_chain_len() as u32,
                 self.header_chain.total_filters_synced(),
-                self.header_chain.internally_cached_headers() as u32,
+                self.header_chain.internal_chain_len() as u32,
             )
         );
     }

--- a/src/chain/graph.rs
+++ b/src/chain/graph.rs
@@ -484,8 +484,8 @@ impl BlockTree {
         locators.into_iter().rev().collect()
     }
 
-    pub(crate) fn internally_cached_headers(&self) -> usize {
-        self.headers.len()
+    pub(crate) fn internal_chain_len(&self) -> usize {
+        self.canonical_hashes.len()
     }
 
     pub(crate) fn iter_data(&self) -> BlockNodeIterator {

--- a/src/chain/mod.rs
+++ b/src/chain/mod.rs
@@ -198,7 +198,7 @@ trait HeightExt: Clone + Copy + std::hash::Hash + PartialEq + Eq + PartialOrd + 
     fn from_u64_checked(height: u64) -> Option<Self>;
 
     fn is_adjustment_multiple(&self, params: impl AsRef<Params>) -> bool;
-    #[allow(unused)]
+
     fn last_epoch_start(&self, params: impl AsRef<Params>) -> Self;
 }
 

--- a/src/network/dns.rs
+++ b/src/network/dns.rs
@@ -170,11 +170,11 @@ impl DNSQuery {
         if amt < HEADER_BYTES {
             return Err(DNSQueryError::MalformedHeader);
         }
-        let ips = self.parse_message(&response_buf[..amt]).await?;
+        let ips = self.parse_message(&response_buf[..amt])?;
         Ok(ips)
     }
 
-    async fn parse_message(&self, mut response: &[u8]) -> Result<Vec<IpAddr>, DNSQueryError> {
+    fn parse_message(&self, mut response: &[u8]) -> Result<Vec<IpAddr>, DNSQueryError> {
         let mut ips = Vec::with_capacity(10);
         let mut buf: [u8; 2] = [0, 0];
         response


### PR DESCRIPTION
- Remove unnecessary `async` in DNS processing step
- Remove unneeded lint in `HeightExt`
- Fix chain logging by changing `internally_cached_headers` to the height of the canonical chain