### PR TITLE
Remove `FilterSyncPolicy`

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -16,7 +16,7 @@ use crate::{
     chain::checkpoints::HeaderCheckpoint,
     db::traits::{HeaderStore, PeerStore},
 };
-use crate::{FilterSyncPolicy, LogLevel, PeerStoreSizeConfig, TrustedPeer};
+use crate::{LogLevel, PeerStoreSizeConfig, TrustedPeer};
 
 #[cfg(feature = "rusqlite")]
 /// The default node returned from the [`NodeBuilder`].
@@ -208,14 +208,6 @@ impl NodeBuilder {
         let ip_addr = proxy.into();
         let connection = ConnectionType::Socks5Proxy(ip_addr);
         self.config.connection_type = connection;
-        self
-    }
-
-    /// Stop the node from downloading and checking compact block filters until an explicit command by the client is made.
-    /// This is only useful if the scripts to check for may not be known do to some expensive computation, like in a silent
-    /// payments context.
-    pub fn halt_filter_download(mut self) -> Self {
-        self.config.filter_sync_policy = FilterSyncPolicy::Halt;
         self
     }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -237,18 +237,6 @@ impl Requester {
             .map_err(|_| ClientError::SendError)
     }
 
-    /// Explicitly start the block filter syncing process. Note that the node will automatically download and check
-    /// filters unless the policy is to explicitly halt.
-    ///
-    /// # Errors
-    ///
-    /// If the node has stopped running.
-    pub fn continue_download(&self) -> Result<(), ClientError> {
-        self.ntx
-            .send(ClientMessage::ContinueDownload)
-            .map_err(|_| ClientError::SendError)
-    }
-
     /// Check if the node is running.
     pub fn is_running(&self) -> bool {
         self.ntx.send(ClientMessage::NoOp).is_ok()

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,7 +5,7 @@ use bitcoin::ScriptBuf;
 use crate::{
     chain::checkpoints::HeaderCheckpoint,
     network::{dns::DnsResolver, ConnectionType},
-    FilterSyncPolicy, LogLevel, PeerStoreSizeConfig, PeerTimeoutConfig, TrustedPeer,
+    LogLevel, PeerStoreSizeConfig, PeerTimeoutConfig, TrustedPeer,
 };
 
 const REQUIRED_PEERS: u8 = 1;
@@ -20,7 +20,6 @@ pub(crate) struct NodeConfig {
     pub connection_type: ConnectionType,
     pub target_peer_size: PeerStoreSizeConfig,
     pub peer_timeout_config: PeerTimeoutConfig,
-    pub filter_sync_policy: FilterSyncPolicy,
     pub log_level: LogLevel,
 }
 
@@ -36,7 +35,6 @@ impl Default for NodeConfig {
             connection_type: Default::default(),
             target_peer_size: PeerStoreSizeConfig::default(),
             peer_timeout_config: PeerTimeoutConfig::default(),
-            filter_sync_policy: Default::default(),
             log_level: Default::default(),
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -392,16 +392,6 @@ pub enum LogLevel {
     Warning,
 }
 
-/// Should the node immediately download filters or wait for a command
-#[derive(Debug, Default)]
-pub enum FilterSyncPolicy {
-    /// The node will wait for an explicit command to start downloading and checking filters
-    Halt,
-    /// Filters are downloaded immediately after CBF headers are synced.
-    #[default]
-    Continue,
-}
-
 /// The state of the node with respect to connected peers.
 #[derive(Debug, Clone, Copy)]
 pub enum NodeState {

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -141,10 +141,6 @@ pub(crate) enum ClientMessage {
     AddScript(ScriptBuf),
     /// Starting at the configured anchor checkpoint, look for block inclusions with newly added scripts.
     Rescan,
-    /// If the [`FilterSyncPolicy`] is set to `Halt`, issuing this command will
-    /// start the filter download and checking process. Otherwise, this command will not have any effect
-    /// on node operation.
-    ContinueDownload,
     /// Explicitly request a block from the node.
     #[cfg(feature = "filter-control")]
     GetBlock(BlockRequest),


### PR DESCRIPTION
The original intention with this configuration was so a silent-payments wallet could fetch key tweaks for a block before downloading filters. I was experimenting with a silent-payments sync, and in practice this is actually a bad idea. The disk space required to store key tweaks for a full block would far exceed the size of the filter. This API path should be discouraged, and instead the implementation should store the filters however they like, then request the key tweaks and dispose of them. This also cleans up the syncing state-machine and allows a removal of a mostly pointless integration test.