### PR TITLE
Emit `Info` after actual TX gossip

### DIFF
--- a/src/network/peer.rs
+++ b/src/network/peer.rs
@@ -15,6 +15,7 @@ use crate::{
     channel_messages::{MainThreadMessage, PeerMessage, PeerThreadMessage},
     dialog::Dialog,
     messages::Warning,
+    Info,
 };
 
 use super::{
@@ -262,6 +263,7 @@ impl Peer {
                     if let Some(transaction) = self.tx_queue.remove(&wtxid) {
                         let msg = message_generator.broadcast_transaction(transaction)?;
                         self.write_bytes(writer, msg).await?;
+                        crate::info!(self.dialog, Info::TxGossiped(wtxid))
                     }
                 }
                 Ok(())

--- a/src/node.rs
+++ b/src/node.rs
@@ -375,9 +375,7 @@ impl<H: HeaderStore, P: PeerStore> Node<H, P> {
                             .await
                     }
                 };
-                if did_broadcast {
-                    crate::info!(self.dialog, Info::TxSent(txid));
-                } else {
+                if !did_broadcast {
                     self.dialog.send_warning(Warning::TransactionRejected {
                         payload: RejectPayload::from_txid(txid),
                     });


### PR DESCRIPTION
The traditional paradigm of submitting a transaction to a server and consdering it "sent" doesn't really apply to the node. If a user is broadcasting a new transaction, it cannot possibly be in another node's mempool, so they will request a `getdata`. At this point, it is fairly certain the transaction will propagate, but the transaction may still be rejected in the future for having insufficient fee or non-standard struture. The best we can do is say "this transaction was gossiped" but there is no notion of this transaction is sent and will definitely be in the remote mempool.