### PR TITLE
Allow `Peer` to manage gossiped peers

### DIFF
--- a/src/channel_messages.rs
+++ b/src/channel_messages.rs
@@ -61,7 +61,6 @@ pub(crate) struct PeerThreadMessage {
 #[derive(Debug)]
 pub(crate) enum PeerMessage {
     Version(VersionMessage),
-    Addr(Vec<CombinedAddr>),
     Headers(Vec<Header>),
     FilterHeaders(CFHeaders),
     Filter(CFilter),

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -43,6 +43,15 @@ impl PersistedPeer {
             status,
         }
     }
+
+    pub(crate) fn gossiped(addr: AddrV2, port: u16, services: ServiceFlags) -> Self {
+        Self {
+            addr,
+            port,
+            services,
+            status: PeerStatus::Gossiped,
+        }
+    }
 }
 
 impl From<PersistedPeer> for (AddrV2, u16) {


### PR DESCRIPTION
Allowing the `Peer` type to add values to the database unblocks the main task when new peers are gossiped to the node. The `PeerStore` requires a static lifetime for the node to work (see `NodeBuilder`), so the restriction is only making it explicit here.

Bitcoin Core will rarely and randomly gossip one or two peers during a connection. These don't require a new task to add, so I made a threshold of 10 to actually begin a sub-task. The sub task just takes a single lock on the database and adds all the addresses gossiped. This tidies up the `PeerMap` and `Node` at the expense of making `Peer` more involved. 

Locally this does as I intended, and the header sync can occur while gossiped peers are added in the background. 

This is one possible solution to #367 