### PR TITLE
fix: actually show percentage and fix up runtime docs

### DIFF
--- a/src/messages.rs
+++ b/src/messages.rs
@@ -109,8 +109,13 @@ impl Progress {
         }
     }
 
-    /// The total progress represented as a fraction.
+    /// The total progress represented as a percent.
     pub fn percentage_complete(&self) -> f32 {
+        self.fraction_complete() * 100.0
+    }
+
+    /// The total progress represented as a fraction.
+    pub fn fraction_complete(&self) -> f32 {
         let total = (2 * self.total_to_check) as f32;
         (self.filter_headers + self.filters) as f32 / total
     }


### PR DESCRIPTION
Fix a mismatch in the `percentage_complete` name and return value, which returns a fraction not a percent.

Also rewrote the runtime docs since I believe the _multithreaded_ stuff was misleading. `spawn` doesn't require a multithreaded runtime as far as I understand. Co-opted the section to mention how the non-obvious runtime requirements of node and client.