### PR TITLE
Introduce `ReaderMessage`

### DIFF
--- a/src/channel_messages.rs
+++ b/src/channel_messages.rs
@@ -50,6 +50,18 @@ pub(crate) enum PeerMessage {
     Filter(CFilter),
     Block(Block),
     NewBlocks(Vec<BlockHash>),
+    FeeFilter(FeeRate),
+}
+
+#[derive(Debug)]
+pub(crate) enum ReaderMessage {
+    Version(VersionMessage),
+    Addr(Vec<CombinedAddr>),
+    Headers(Vec<Header>),
+    FilterHeaders(CFHeaders),
+    Filter(CFilter),
+    Block(Block),
+    NewBlocks(Vec<BlockHash>),
     Reject(RejectPayload),
     Disconnect,
     Verack,

--- a/src/node.rs
+++ b/src/node.rs
@@ -227,15 +227,10 @@ impl<H: HeaderStore, P: PeerStore> Node<H, P> {
                                         None => continue,
                                     }
                                 }
-                                PeerMessage::Reject(payload) => {
-                                    self.dialog
-                                        .send_warning(Warning::TransactionRejected { payload });
-                                }
                                 PeerMessage::FeeFilter(feerate) => {
                                     let mut peer_map = self.peer_map.lock().await;
                                     peer_map.set_broadcast_min(peer_thread.nonce, feerate);
                                 }
-                                _ => continue,
                             }
                         },
                         _ => continue,

--- a/tests/core.rs
+++ b/tests/core.rs
@@ -27,7 +27,8 @@ fn start_bitcoind(with_v2_transport: bool) -> anyhow::Result<(corepc_node::Node,
     conf.args.push("--rest=1");
     conf.args.push("--server=1");
     conf.args.push("--listen=1");
-    conf.tmpdir = Some(tempfile::TempDir::new().unwrap().into_path());
+    let tempdir = tempfile::TempDir::new()?;
+    conf.tmpdir = Some(tempdir.path().to_owned());
     if with_v2_transport {
         conf.args.push("--v2transport=1")
     } else {
@@ -119,7 +120,7 @@ async fn print_logs(mut log_rx: Receiver<String>, mut warn_rx: UnboundedReceiver
 async fn live_reorg() {
     let (bitcoind, socket_addr) = start_bitcoind(true).unwrap();
     let rpc = &bitcoind.client;
-    let tempdir = tempfile::TempDir::new().unwrap().into_path();
+    let tempdir = tempfile::TempDir::new().unwrap().path().to_owned();
     // Mine some blocks
     let miner = rpc.new_address().unwrap();
     mine_blocks(rpc, &miner, 10, 1).await;
@@ -169,7 +170,7 @@ async fn live_reorg() {
 async fn live_reorg_additional_sync() {
     let (bitcoind, socket_addr) = start_bitcoind(true).unwrap();
     let rpc = &bitcoind.client;
-    let tempdir = tempfile::TempDir::new().unwrap().into_path();
+    let tempdir = tempfile::TempDir::new().unwrap().path().to_owned();
     // Mine some blocks
     let miner = rpc.new_address().unwrap();
     mine_blocks(rpc, &miner, 10, 1).await;
@@ -223,7 +224,7 @@ async fn live_reorg_additional_sync() {
 async fn various_client_methods() {
     let (bitcoind, socket_addr) = start_bitcoind(true).unwrap();
     let rpc = &bitcoind.client;
-    let tempdir = tempfile::TempDir::new().unwrap().into_path();
+    let tempdir = tempfile::TempDir::new().unwrap().path().to_owned();
     // Mine a lot of blocks
     let miner = rpc.new_address().unwrap();
     mine_blocks(rpc, &miner, 500, 15).await;
@@ -257,7 +258,7 @@ async fn various_client_methods() {
 async fn stop_reorg_resync() {
     let (bitcoind, socket_addr) = start_bitcoind(true).unwrap();
     let rpc = &bitcoind.client;
-    let tempdir = tempfile::TempDir::new().unwrap().into_path();
+    let tempdir: PathBuf = tempfile::TempDir::new().unwrap().path().to_owned();
     // Mine some blocks.
     let miner = rpc.new_address().unwrap();
     mine_blocks(rpc, &miner, 10, 1).await;
@@ -338,7 +339,7 @@ async fn stop_reorg_resync() {
 async fn stop_reorg_two_resync() {
     let (bitcoind, socket_addr) = start_bitcoind(true).unwrap();
     let rpc = &bitcoind.client;
-    let tempdir = tempfile::TempDir::new().unwrap().into_path();
+    let tempdir: PathBuf = tempfile::TempDir::new().unwrap().path().to_owned();
     // Mine some blocks.
     let miner = rpc.new_address().unwrap();
     mine_blocks(rpc, &miner, 10, 1).await;
@@ -419,7 +420,7 @@ async fn stop_reorg_two_resync() {
 async fn stop_reorg_start_on_orphan() {
     let (bitcoind, socket_addr) = start_bitcoind(true).unwrap();
     let rpc = &bitcoind.client;
-    let tempdir = tempfile::TempDir::new().unwrap().into_path();
+    let tempdir: PathBuf = tempfile::TempDir::new().unwrap().path().to_owned();
     let miner = rpc.new_address().unwrap();
     mine_blocks(rpc, &miner, 17, 3).await;
     let best = best_hash(rpc);
@@ -532,7 +533,7 @@ async fn stop_reorg_start_on_orphan() {
 
 #[tokio::test]
 async fn signet_syncs() {
-    let tempdir = tempfile::TempDir::new().unwrap().into_path();
+    let tempdir: PathBuf = tempfile::TempDir::new().unwrap().path().to_owned();
     let address = bitcoin::Address::from_str("tb1q9pvjqz5u5sdgpatg3wn0ce438u5cyv85lly0pc")
         .unwrap()
         .require_network(bitcoin::Network::Signet)


### PR DESCRIPTION
The `Reader` produces a subset of the `NetworkMessage` that are relevant to the light client, omitting things like compact block relay. The condensed message is called `PeerMessage`, which is passed to both `Peer` and the main thread. The `Peer` is doing some filtering as well. For instance the `Peer` can respond to `Ping` messages, and the main thread does not need to know about them. The `PeerMessage` should be anything that is worthy of going to the main thread, which in the ideal case is block headers, compact block filters, filters, inventory messages of block announcements. Everything else can be handled by `Peer`, including address gossip at some point.

The diff is a little confusing, because `PeerMessage` got renamed to `ReaderMessage` and is the exact same, then `PeerMessage` is the consolidated p2p messages that would be interesting to the main thread. The only functional change is that the `Peer` sends the reject message directly using the `Dialog` it already had.