### PR TITLE
Add transaction broadcast test

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ rusqlite = ["dep:rusqlite"]
 filter-control = []
 
 [dev-dependencies]
-corepc-node = { version = "0.6.1", default-features = false, features = [
+corepc-node = { version = "0.7.1", default-features = false, features = [
     "28_0", "download"
 ] }
 hex = { version = "0.4.0" }


### PR DESCRIPTION
AFICT the only way to build a transaction that the Regtest instance does not known about is to send money to a key outside of the Regtest wallet, then broadcast a transaction signed from that key. Unfortunately that makes this test pretty nasty in terms of implementation. I think the only thing I may have overlooked is the RPC `createrawtransaction` but that RPC still involves some inputs that might be difficult to fetch. Thankfully there is a `rust-bitcoin` example of signing a transaction, so I went ahead and yanked a bunch of logic there.

ref: https://github.com/rust-bitcoin/rust-bitcoin/blob/master/bitcoin/examples/sign-tx-taproot.rs