### PR TITLE
Unpin `bitcoin` patch version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["cryptography::cryptocurrencies"]
 rust-version = "1.63.0"
 
 [dependencies]
-bitcoin = { version = "0.32.5", default-features = false, features = [
+bitcoin = { version = "0.32", default-features = false, features = [
     "rand-std",
 ] }
 bip324 = { version = "0.7.0", default-features = false, features = [

--- a/tests/core.rs
+++ b/tests/core.rs
@@ -607,7 +607,7 @@ async fn tx_can_broadcast() {
         .unwrap();
     let tweaked: bitcoin::key::TweakedKeypair = keypair.tap_tweak(&secp, None);
     let msg = bitcoin::secp256k1::Message::from(sighash);
-    let signature = secp.sign_schnorr(&msg, &tweaked.to_inner());
+    let signature = secp.sign_schnorr(&msg, &tweaked.to_keypair());
     let signature = bitcoin::taproot::Signature {
         signature,
         sighash_type,


### PR DESCRIPTION
Cargo check seems to ignore the pinned version of `bitcoin` to `0.32.5` and builds `0.32.6`. This results in a new lint. We should be picking up patch releases from `bitcoin` anyway. Unpinning the `.5`