### PR TITLE
deps: pin `bitcoin` to `0.32.6`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["cryptography::cryptocurrencies"]
 rust-version = "1.63.0"
 
 [dependencies]
-bitcoin = { version = "0.32", default-features = false, features = [
+bitcoin = { version = "0.32.6", default-features = false, features = [
     "rand-std",
 ] }
 bip324 = { version = "0.7.0", default-features = false, features = [


### PR DESCRIPTION
This was a test to determine the behavior of the `min-versions` test. For context, `bitcoin = 0.32.6` deprecated a method, which was causing the `check` CI tests to fail. To fix that, I unpinned the `bitcoin` patch version, such that any valid `0.32` is selected in the `Cargo.toml` when building the library. This resolved the CI failure, as `0.32.6` was selected, but the min-versions failed.

The `0.32` allows a selection of _any_ patch version. Yet the `min-versions` test failed because, technically in the test suite, the minimal version is `0.32.6`. My question is how was `0.32.6` not simply selected by cargo? `0.32` should allow that to happen? I think `min-versions` might be overly pedantic for the crate at the moment.

This PR proves the CI passes on `min-versions` when pinning to `.6` in `Cargo.toml`, but this feels to strict considering this was a test dependency. Any patch version that the user is bringing from `bitcoin` should work.