### PR TITLE
Strictly handle reject messages

### DIFF
--- a/src/messages.rs
+++ b/src/messages.rs
@@ -2,7 +2,7 @@ use std::{collections::BTreeMap, ops::Range, time::Duration};
 
 #[cfg(feature = "filter-control")]
 use bitcoin::BlockHash;
-use bitcoin::{block::Header, p2p::message_network::RejectReason, FeeRate, ScriptBuf, Txid, Wtxid};
+use bitcoin::{block::Header, p2p::message_network::RejectReason, FeeRate, ScriptBuf, Wtxid};
 
 #[cfg(feature = "filter-control")]
 use crate::IndexedFilter;
@@ -127,12 +127,15 @@ pub struct RejectPayload {
     /// An enumeration of the reason for the transaction failure. If none is provided, the message could not be sent over the wire.
     pub reason: Option<RejectReason>,
     /// The transaction that was rejected or failed to broadcast.
-    pub txid: Txid,
+    pub wtxid: Wtxid,
 }
 
 impl RejectPayload {
-    pub(crate) fn from_txid(txid: Txid) -> Self {
-        Self { reason: None, txid }
+    pub(crate) fn from_wtxid(wtxid: Wtxid) -> Self {
+        Self {
+            reason: None,
+            wtxid,
+        }
     }
 }
 
@@ -289,7 +292,7 @@ impl core::fmt::Display for Warning {
                 )
             }
             Warning::TransactionRejected { payload } => {
-                write!(f, "A transaction got rejected: TXID {}", payload.txid)
+                write!(f, "A transaction got rejected: WTXID {}", payload.wtxid)
             }
             Warning::FailedPersistence { warning } => {
                 write!(f, "A database failed to persist some data: {warning}")

--- a/src/network/counter.rs
+++ b/src/network/counter.rs
@@ -14,7 +14,6 @@ pub(crate) struct MessageCounter {
     filters: i64,
     addrs: i32,
     block: i32,
-    tx: i32,
 }
 
 impl MessageCounter {
@@ -26,7 +25,6 @@ impl MessageCounter {
             filters: 0,
             addrs: 0,
             block: 0,
-            tx: 0,
         }
     }
 
@@ -53,10 +51,6 @@ impl MessageCounter {
         self.block -= 1;
     }
 
-    pub(crate) fn got_reject(&mut self) {
-        self.tx -= 1;
-    }
-
     pub(crate) fn sent_header(&mut self) {
         self.timer.track();
     }
@@ -80,17 +74,12 @@ impl MessageCounter {
         self.block += 1;
     }
 
-    pub(crate) fn sent_tx(&mut self) {
-        self.tx += 1;
-    }
-
     pub(crate) fn unsolicited(&self) -> bool {
         self.header < 0
             || self.filters < 0
             || self.filter_header < 0
             || self.addrs < 0
             || self.block < 0
-            || self.tx < 0
     }
 
     pub(crate) fn unresponsive(&self) -> bool {

--- a/src/network/reader.rs
+++ b/src/network/reader.rs
@@ -2,7 +2,7 @@ use std::net::IpAddr;
 
 use bitcoin::p2p::address::AddrV2;
 use bitcoin::p2p::{message::NetworkMessage, message_blockdata::Inventory, ServiceFlags};
-use bitcoin::{FeeRate, Txid};
+use bitcoin::{FeeRate, Wtxid};
 use tokio::io::AsyncReadExt;
 use tokio::sync::mpsc::Sender;
 
@@ -139,10 +139,10 @@ impl<R: AsyncReadExt + Send + Sync + Unpin> Reader<R> {
             NetworkMessage::BlockTxn(_) => None,
             NetworkMessage::Alert(_) => None,
             NetworkMessage::Reject(rejection) => {
-                let txid = Txid::from(rejection.hash);
+                let wtxid = Wtxid::from(rejection.hash);
                 Some(ReaderMessage::Reject(RejectPayload {
                     reason: Some(rejection.ccode),
-                    txid,
+                    wtxid,
                 }))
             }
             // 70013

--- a/src/node.rs
+++ b/src/node.rs
@@ -352,7 +352,7 @@ impl<H: HeaderStore, P: PeerStore> Node<H, P> {
         let mut peer_map = self.peer_map.lock().await;
         if peer_map.live().ge(&self.required_peers) {
             for transaction in broadcaster.queue() {
-                let txid = transaction.tx.compute_txid();
+                let wtxid = transaction.tx.compute_wtxid();
                 let did_broadcast = match transaction.broadcast_policy {
                     TxBroadcastPolicy::AllPeers => {
                         crate::log!(
@@ -372,7 +372,7 @@ impl<H: HeaderStore, P: PeerStore> Node<H, P> {
                 };
                 if !did_broadcast {
                     self.dialog.send_warning(Warning::TransactionRejected {
-                        payload: RejectPayload::from_txid(txid),
+                        payload: RejectPayload::from_wtxid(wtxid),
                     });
                 }
             }


### PR DESCRIPTION
Continual refactor to remove items from `counter.rs`. When we send a transaction, we only expect a single reject message, if any. The `MessageState` now closely tracks which transactions were broadcast and if we have already been informed that they were rejected. This prevents the remote peer from sending random reject messages.