### PR TITLE
Annouce txs after `verack`

### DIFF
--- a/tests/core.rs
+++ b/tests/core.rs
@@ -639,11 +639,9 @@ async fn tx_can_broadcast() {
                     if let Some(info) = info {
                         match info {
                             Info::TxGossiped(_) => { break; },
-                            Info::StateChange(u) => {
-                                if let kyoto::NodeState::HeadersSynced = u {
-                                    println!("Broadcasting transaction");
-                                    requester.broadcast_random(tx.clone()).unwrap();
-                                }
+                            Info::ConnectionsMet => {
+                                println!("Broadcasting transaction");
+                                requester.broadcast_random(tx.clone()).unwrap();
                             },
                             _ => println!("{info}"),
                         }


### PR DESCRIPTION
When informed by the main thread that a peer thread must broadcast a transaction, it does so without acknowledging the state of the version handshake with the remote peer. If the handshake is not yet complete, wait until a `verack` is received to advertise the transactions.