### PR TITLE
Return accepted/disconnected headers

### DIFF
--- a/example/signet.rs
+++ b/example/signet.rs
@@ -79,7 +79,7 @@ async fn main() {
                             let hash = indexed_block.block.block_hash();
                             tracing::info!("Received block: {}", hash);
                         },
-                        Event::BlocksDisconnected(_) => {
+                        Event::BlocksDisconnected { accepted: _, disconnected: _} => {
                             tracing::warn!("Some blocks were reorganized")
                         },
                     }

--- a/example/testnet4.rs
+++ b/example/testnet4.rs
@@ -65,7 +65,7 @@ async fn main() {
                             let hash = indexed_block.block.block_hash();
                             tracing::info!("Received block: {}", hash);
                         },
-                        Event::BlocksDisconnected(_) => {
+                        Event::BlocksDisconnected { accepted: _, disconnected: _ } => {
                             tracing::warn!("Some blocks were reorganized")
                         },
                     }

--- a/src/chain/mod.rs
+++ b/src/chain/mod.rs
@@ -29,12 +29,24 @@ use error::FilterError;
 type Height = u32;
 
 /// A block header with associated height.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct IndexedHeader {
     /// The height in the blockchain for this header.
     pub height: u32,
     /// The block header.
     pub header: Header,
+}
+
+impl std::cmp::PartialOrd for IndexedHeader {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.height.cmp(&other.height))
+    }
+}
+
+impl std::cmp::Ord for IndexedHeader {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.height.cmp(&other.height)
+    }
 }
 
 impl IndexedHeader {

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -54,7 +54,12 @@ pub enum Event {
     /// The node is fully synced, having scanned the requested range.
     Synced(SyncUpdate),
     /// Blocks were reorganized out of the chain.
-    BlocksDisconnected(Vec<IndexedHeader>),
+    BlocksDisconnected {
+        /// Blocks that were accepted to the chain of most work in ascending order by height.
+        accepted: Vec<IndexedHeader>,
+        /// Blocks that were disconnected from the chain of most work in ascending order by height.
+        disconnected: Vec<IndexedHeader>,
+    },
     /// A compact block filter with associated height and block hash.
     #[cfg(feature = "filter-control")]
     IndexedFilter(IndexedFilter),

--- a/tests/core.rs
+++ b/tests/core.rs
@@ -159,7 +159,10 @@ async fn live_reorg() {
     // Make sure the reorg was caught
     while let Some(message) = channel.recv().await {
         match message {
-            kyoto::messages::Event::BlocksDisconnected(blocks) => {
+            kyoto::messages::Event::BlocksDisconnected {
+                accepted: _,
+                disconnected: blocks,
+            } => {
                 assert_eq!(blocks.len(), 1);
                 assert_eq!(blocks.first().unwrap().header.block_hash(), old_best);
                 assert_eq!(old_height as u32, blocks.first().unwrap().height);
@@ -211,7 +214,10 @@ async fn live_reorg_additional_sync() {
     // Make sure the reorg was caught
     while let Some(message) = channel.recv().await {
         match message {
-            kyoto::messages::Event::BlocksDisconnected(blocks) => {
+            kyoto::messages::Event::BlocksDisconnected {
+                accepted: _,
+                disconnected: blocks,
+            } => {
                 assert_eq!(blocks.len(), 1);
                 assert_eq!(blocks.first().unwrap().header.block_hash(), old_best);
                 assert_eq!(old_height as u32, blocks.first().unwrap().height);
@@ -310,7 +316,10 @@ async fn stop_reorg_resync() {
     // Make sure the reorganization is caught after a cold start
     while let Some(message) = channel.recv().await {
         match message {
-            kyoto::messages::Event::BlocksDisconnected(blocks) => {
+            kyoto::messages::Event::BlocksDisconnected {
+                accepted: _,
+                disconnected: blocks,
+            } => {
                 assert_eq!(blocks.len(), 1);
                 assert_eq!(blocks.first().unwrap().header.block_hash(), old_best);
                 assert_eq!(old_height as u32, blocks.first().unwrap().height);
@@ -391,7 +400,10 @@ async fn stop_reorg_two_resync() {
     let handle = tokio::task::spawn(async move { print_logs(log_rx, warn_rx).await });
     while let Some(message) = channel.recv().await {
         match message {
-            kyoto::messages::Event::BlocksDisconnected(blocks) => {
+            kyoto::messages::Event::BlocksDisconnected {
+                accepted: _,
+                disconnected: blocks,
+            } => {
                 assert_eq!(blocks.len(), 2);
                 assert_eq!(blocks.last().unwrap().header.block_hash(), old_best);
                 assert_eq!(old_height as u32, blocks.last().unwrap().height);
@@ -475,7 +487,10 @@ async fn stop_reorg_start_on_orphan() {
     // Ensure SQL is able to catch the fork by loading in headers from the database
     while let Some(message) = channel.recv().await {
         match message {
-            kyoto::messages::Event::BlocksDisconnected(blocks) => {
+            kyoto::messages::Event::BlocksDisconnected {
+                accepted: _,
+                disconnected: blocks,
+            } => {
                 assert_eq!(blocks.len(), 1);
                 assert_eq!(blocks.first().unwrap().header.block_hash(), old_best);
                 assert_eq!(old_height as u32, blocks.first().unwrap().height);


### PR DESCRIPTION
At the moment the only information returned by `BlocksDisconnected` is the blocks that were reorganized, but some sources of the data may also be able to make use of the accepted headers. For instance they may simply replace the old value at the height with the new one. Here we return that data, as well as make the ordering explicit in terms of height.