### PR TITLE
Introduce `BroadcastQueue` to manage a global tx broadcasting state

### DIFF
--- a/src/broadcaster.rs
+++ b/src/broadcaster.rs
@@ -1,30 +1,36 @@
-use crate::TxBroadcast;
+use std::collections::{HashMap, HashSet};
 
-#[derive(Debug, Clone)]
-pub(crate) struct Broadcaster {
-    queue: Vec<TxBroadcast>,
+use bitcoin::{Transaction, Wtxid};
+
+#[derive(Debug, Clone, Default)]
+pub(crate) struct BroadcastQueue {
+    pending: HashSet<Wtxid>,
+    data: HashMap<Wtxid, Transaction>,
 }
 
-impl Broadcaster {
+impl BroadcastQueue {
     pub(crate) fn new() -> Self {
-        Self { queue: Vec::new() }
+        Self {
+            ..Default::default()
+        }
     }
 
-    pub(crate) fn add(&mut self, tx: TxBroadcast) {
-        self.queue.push(tx)
+    pub(crate) fn add_to_queue(&mut self, tx: Transaction) {
+        let wtxid = tx.compute_wtxid();
+        self.pending.insert(wtxid);
+        self.data.insert(wtxid, tx);
     }
 
-    pub(crate) fn is_empty(&self) -> bool {
-        self.queue.is_empty()
+    pub(crate) fn fetch_tx(&self, wtxid: Wtxid) -> Option<Transaction> {
+        self.data.get(&wtxid).cloned()
     }
 
-    pub(crate) fn queue(&mut self) -> Vec<TxBroadcast> {
-        core::mem::take(&mut self.queue)
+    pub(crate) fn successful(&mut self, wtxid: Wtxid) {
+        self.pending.remove(&wtxid);
     }
 
-    #[allow(dead_code)]
-    pub(crate) fn next(&mut self) -> Option<TxBroadcast> {
-        self.queue.pop()
+    pub(crate) fn pending_wtxid(&self) -> Vec<Wtxid> {
+        self.pending.iter().copied().collect()
     }
 }
 
@@ -32,31 +38,22 @@ impl Broadcaster {
 mod tests {
     use bitcoin::{consensus::deserialize, Transaction};
 
-    use crate::TxBroadcast;
-
-    use super::Broadcaster;
+    use super::BroadcastQueue;
 
     #[test]
     fn test_broadcast_queue_works() {
         // Sourced from BIP 174 test vectors
         let transaction_1: Transaction = deserialize(&hex::decode("0200000000010158e87a21b56daf0c23be8e7070456c336f7cbaa5c8757924f545887bb2abdd7501000000171600145f275f436b09a8cc9a2eb2a2f528485c68a56323feffffff02d8231f1b0100000017a914aed962d6654f9a2b36608eb9d64d2b260db4f1118700c2eb0b0000000017a914b7f5faf40e3d40a5a459b1db3535f2b72fa921e88702483045022100a22edcc6e5bc511af4cc4ae0de0fcd75c7e04d8c1c3a8aa9d820ed4b967384ec02200642963597b9b1bc22c75e9f3e117284a962188bf5e8a74c895089046a20ad770121035509a48eb623e10aace8bfd0212fdb8a8e5af3c94b0b133b95e114cab89e4f7965000000").unwrap()).unwrap();
         let transaction_2: Transaction = deserialize(&hex::decode("0200000001aad73931018bd25f84ae400b68848be09db706eac2ac18298babee71ab656f8b0000000048473044022058f6fc7c6a33e1b31548d481c826c015bd30135aad42cd67790dab66d2ad243b02204a1ced2604c6735b6393e5b41691dd78b00f0c5942fb9f751856faa938157dba01feffffff0280f0fa020000000017a9140fb9463421696b82c833af241c78c17ddbde493487d0f20a270100000017a91429ca74f8a08f81999428185c97b5d852e4063f618765000000").unwrap()).unwrap();
-        let tx_1 = TxBroadcast::new(transaction_1, crate::TxBroadcastPolicy::AllPeers);
-        let tx_2 = TxBroadcast::new(transaction_2, crate::TxBroadcastPolicy::AllPeers);
-        let mut queue = Broadcaster::new();
-        assert!(queue.is_empty());
-        queue.add(tx_1.clone());
-        assert!(!queue.is_empty());
-        let tx = queue.next();
-        assert!(tx.is_some());
-        assert!(queue.is_empty());
-        queue.add(tx_1);
-        queue.add(tx_2.clone());
-        assert!(!queue.is_empty());
-        let txs = queue.queue();
-        assert_eq!(txs.len(), 2);
-        assert!(queue.is_empty());
-        queue.add(tx_2);
-        assert!(!queue.is_empty());
+        let mut queue = BroadcastQueue::new();
+        queue.add_to_queue(transaction_1.clone());
+        queue.add_to_queue(transaction_2.clone());
+        assert_eq!(queue.pending_wtxid().len(), 2);
+        queue.successful(transaction_1.compute_wtxid());
+        assert_eq!(queue.pending_wtxid().len(), 1);
+        assert!(queue.fetch_tx(transaction_1.compute_wtxid()).is_some());
+        assert!(queue.fetch_tx(transaction_2.compute_wtxid()).is_some());
+        queue.successful(transaction_2.compute_wtxid());
+        assert_eq!(queue.pending_wtxid().len(), 0);
     }
 }

--- a/src/channel_messages.rs
+++ b/src/channel_messages.rs
@@ -6,7 +6,7 @@ use bitcoin::{
         message_network::VersionMessage,
         ServiceFlags,
     },
-    Block, BlockHash, FeeRate, Transaction, Wtxid,
+    Block, BlockHash, FeeRate, Wtxid,
 };
 
 use crate::{messages::RejectPayload, network::PeerId};
@@ -21,7 +21,7 @@ pub(crate) enum MainThreadMessage {
     GetFilters(GetCFilters),
     GetBlock(GetBlockConfig),
     Disconnect,
-    BroadcastTx(Transaction),
+    BroadcastPending,
     Verack,
 }
 

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -135,15 +135,6 @@ pub struct RejectPayload {
     pub wtxid: Wtxid,
 }
 
-impl RejectPayload {
-    pub(crate) fn from_wtxid(wtxid: Wtxid) -> Self {
-        Self {
-            reason: None,
-            wtxid,
-        }
-    }
-}
-
 /// Commands to issue a node.
 #[derive(Debug)]
 pub(crate) enum ClientMessage {

--- a/src/network/outbound_messages.rs
+++ b/src/network/outbound_messages.rs
@@ -103,8 +103,11 @@ impl MessageGenerator {
         self.serialize(msg)
     }
 
-    pub(crate) fn announce_transaction(&mut self, wtxid: Wtxid) -> Result<Vec<u8>, PeerError> {
-        let msg = NetworkMessage::Inv(vec![Inventory::WTx(wtxid)]);
+    pub(crate) fn announce_transactions(
+        &mut self,
+        wtxids: Vec<Wtxid>,
+    ) -> Result<Vec<u8>, PeerError> {
+        let msg = NetworkMessage::Inv(wtxids.into_iter().map(Inventory::WTx).collect());
         self.serialize(msg)
     }
 

--- a/tests/core.rs
+++ b/tests/core.rs
@@ -642,6 +642,7 @@ async fn tx_can_broadcast() {
         mut warn_rx,
         mut event_rx,
     } = client;
+    requester.broadcast_random(tx).unwrap();
     tokio::time::timeout(tokio::time::Duration::from_secs(60), async move {
         loop {
             tokio::select! {
@@ -654,12 +655,6 @@ async fn tx_can_broadcast() {
                     if let Some(info) = info {
                         match info {
                             Info::TxGossiped(_) => { break; },
-                            Info::StateChange(u) => {
-                                if let kyoto::NodeState::HeadersSynced = u {
-                                    println!("Broadcasting transaction");
-                                    requester.broadcast_random(tx.clone()).unwrap();
-                                }
-                            },
                             _ => println!("{info}"),
                         }
                     }


### PR DESCRIPTION
Broadcasting transactions is currently broken to some degree.

# Description

Broadcasting a transaction should have the following properties:
1. The user should not have to care about what state the node is in (i.e. downloading block headers, filters, looking for connections, etc.)
2. Assuming the transaction is new (RBF and CPFP count as new), all peers we connect to should request a `getdata` from us when we advertise the WTXID. This implies that a broadcast is not successful until responding to a `getdata` with the entire transaction. Thus, the node should continue to broadcast transactions to new connections if there has not been a `getdata` request and successful response.

Fulfilling 2. may violate the precise meaning of `TxBroadcastPolicy::RandomPeer` as a broadcast might require multiple advertisements, but that should be considered acceptable because some applications may have time-sensitive conditions in the transaction. In addition, the `Transaction` will only be sent once.

# Current implementation

The current implementation is a simple queue where a transaction is added, and when the node is ready to broadcast it, the transaction is popped off the queue. There is no failure policy, so if a transaction is popped from the queue, and no remote nodes acknowledge the advertisement, the transaction fails to broadcast. While this does not happen often, it _can_ happen if a user tries to broadcast a transaction very early in the node lifetime.

# Revised implementation

The `BroadcastQueue` is introduced to include failure-protection. This structure is shared by all `Peer` using an `Arc<Mutex<T>>` to ensure all the threads/tasks are in alignment on the state of a transaction broadcast. Pending transactions are announced by `wtxid` in two cases:
1. the user broadcasts a transaction with the `Requester`
2. a transaction is pending, even after making a new connection (after `Verack` is exchanged)

In case number 2., we already tried to broadcast when the user requested, but we haven't received a `getdata` message yet and shared the full transaction. We should try to share the full transaction with the new connection.

Once the transaction has been fully broadcast to a peer, we consider the transaction successful and will no longer broadcast it to new connections. However, if a peer requests a transaction we already consider successfully broadcast, we may still send it to them to speed up network propagation.

#### Notes

- With the built-in failure protection and shared queue behind `Arc<Mutex<T>>`, `Node` may simply direct one or every `Peer` to advertise the transactions. This removes a field from `Node` and makes the broadcasting logic easier to reason about.
- The integration test can try to broadcast the transaction immediately, and the node can handle how to announce the transaction now, which satisfies the first property this PR aims to implement.