### PR TITLE
Make the error impl macro private

### DIFF
--- a/src/channel_messages.rs
+++ b/src/channel_messages.rs
@@ -29,13 +29,14 @@ pub(crate) enum MainThreadMessage {
 
 impl MainThreadMessage {
     pub(crate) fn time_sensitive_message_start(&self) -> Option<(TimeSensitiveId, Instant)> {
-        let now = Instant::now();
         match self {
-            MainThreadMessage::GetHeaders(_) => Some((TimeSensitiveId::HEADER_MSG, now)),
-            MainThreadMessage::GetFilterHeaders(_) => Some((TimeSensitiveId::CF_HEADER_MSG, now)),
+            MainThreadMessage::GetHeaders(_) => Some((TimeSensitiveId::HEADER_MSG, Instant::now())),
+            MainThreadMessage::GetFilterHeaders(_) => {
+                Some((TimeSensitiveId::CF_HEADER_MSG, Instant::now()))
+            }
             MainThreadMessage::GetBlock(conf) => {
                 let id = conf.locator.to_raw_hash().to_byte_array();
-                Some((TimeSensitiveId::from_slice(id), now))
+                Some((TimeSensitiveId::from_slice(id), Instant::now()))
             }
             _ => None,
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,6 +80,7 @@ pub mod db;
 
 mod network;
 mod prelude;
+pub(crate) use prelude::impl_sourceless_error;
 
 mod broadcaster;
 /// Convenient way to build a compact filters node.

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -9,8 +9,6 @@ pub const MEDIAN_TIME_PAST: usize = 11;
 
 pub(crate) type FutureResult<'a, T, E> = Pin<Box<dyn Future<Output = Result<T, E>> + Send + 'a>>;
 
-#[macro_export]
-/// Implement `std::error::Error` for an error with no sources.
 macro_rules! impl_sourceless_error {
     ($e:ident) => {
         impl std::error::Error for $e {
@@ -20,6 +18,8 @@ macro_rules! impl_sourceless_error {
         }
     };
 }
+
+pub(crate) use impl_sourceless_error;
 
 pub trait Median<T> {
     fn median(&mut self) -> T;


### PR DESCRIPTION
This should not be exposed to downstream users just to keep the crate from becoming cluttered. I think it is useful, but they will have to implement it themselves (: