### PR TITLE
Use DNS as a source for initial peers

### DIFF
--- a/example/bitcoin.rs
+++ b/example/bitcoin.rs
@@ -31,6 +31,10 @@ async fn main() {
         .after_checkpoint(checkpoint)
         // The number of connections we would like to maintain
         .required_peers(2)
+        // Random resolver pulled from: https://public-dns.info/nameservers.txt
+        .dns_resolver([185, 220, 182, 179])
+        // Query the DNS resolver on every sync. Read more about the traeoffs in the documentation.
+        .force_dns_seeding()
         // Create the node and client
         .build()
         .unwrap();

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -198,7 +198,18 @@ impl NodeBuilder {
     pub fn dns_resolver(mut self, resolver: impl Into<IpAddr>) -> Self {
         let ip_addr = resolver.into();
         let socket_addr = SocketAddr::new(ip_addr, DNS_RESOLVER_PORT);
-        self.config.dns_resolver = DnsResolver { socket_addr };
+        self.config.dns_config.resolver = DnsResolver { socket_addr };
+        self
+    }
+
+    /// Seed initial peers with DNS, even if there are peers available on disk.
+    ///
+    /// There is an implicit trust tradeoff when using this feature. The DNS seeds are trusted to
+    /// respond with good bitcoin nodes, whereas relying on local storage does not rely on trust.
+    /// This feature should be used with care, and may only be appropriate for certain use-cases
+    /// that do not shut down frequently.
+    pub fn force_dns_seeding(mut self) -> Self {
+        self.config.dns_config.force_seeding = true;
         self
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,7 +4,7 @@ use bitcoin::ScriptBuf;
 
 use crate::{
     chain::checkpoints::HeaderCheckpoint,
-    network::{dns::DnsResolver, ConnectionType},
+    network::{dns::DnsConfig, ConnectionType},
     LogLevel, PeerStoreSizeConfig, PeerTimeoutConfig, TrustedPeer,
 };
 
@@ -13,7 +13,7 @@ const REQUIRED_PEERS: u8 = 1;
 pub(crate) struct NodeConfig {
     pub required_peers: u8,
     pub white_list: Vec<TrustedPeer>,
-    pub dns_resolver: DnsResolver,
+    pub dns_config: DnsConfig,
     pub addresses: HashSet<ScriptBuf>,
     pub data_path: Option<PathBuf>,
     pub header_checkpoint: Option<HeaderCheckpoint>,
@@ -28,7 +28,7 @@ impl Default for NodeConfig {
         Self {
             required_peers: REQUIRED_PEERS,
             white_list: Default::default(),
-            dns_resolver: DnsResolver::default(),
+            dns_config: DnsConfig::default(),
             addresses: Default::default(),
             data_path: Default::default(),
             header_checkpoint: Default::default(),

--- a/src/network/peer_map.rs
+++ b/src/network/peer_map.rs
@@ -1,6 +1,7 @@
 use std::{
     collections::{HashMap, HashSet},
     fmt::Debug,
+    net::IpAddr,
     sync::Arc,
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
@@ -26,12 +27,12 @@ use crate::{
     db::{traits::PeerStore, PeerStatus, PersistedPeer},
     dialog::Dialog,
     error::PeerManagerError,
-    network::{dns::DnsResolver, error::PeerError, peer::Peer, PeerId, PeerTimeoutConfig},
+    network::{dns::Dns, error::PeerError, peer::Peer, PeerId, PeerTimeoutConfig},
     prelude::{default_port_from_network, Median, Netgroup},
     PeerStoreSizeConfig, TrustedPeer, Warning,
 };
 
-use super::ConnectionType;
+use super::{dns::DnsConfig, ConnectionType};
 
 const MAX_TRIES: usize = 50;
 
@@ -66,7 +67,7 @@ pub(crate) struct PeerMap<P: PeerStore + 'static> {
     target_db_size: PeerStoreSizeConfig,
     net_groups: HashSet<String>,
     timeout_config: PeerTimeoutConfig,
-    dns_resolver: DnsResolver,
+    dns_config: DnsConfig,
 }
 
 #[allow(dead_code)]
@@ -82,7 +83,7 @@ impl<P: PeerStore> PeerMap<P> {
         target_db_size: PeerStoreSizeConfig,
         timeout_config: PeerTimeoutConfig,
         height_monitor: Arc<Mutex<HeightMonitor>>,
-        dns_resolver: DnsResolver,
+        dns_config: DnsConfig,
     ) -> Self {
         Self {
             tx_queue: Arc::new(Mutex::new(BroadcastQueue::new())),
@@ -98,7 +99,7 @@ impl<P: PeerStore> PeerMap<P> {
             target_db_size,
             net_groups: HashSet::new(),
             timeout_config,
-            dns_resolver,
+            dns_config,
         }
     }
 
@@ -275,14 +276,6 @@ impl<P: PeerStore> PeerMap<P> {
                 PersistedPeer::new(peer.address, port, peer.known_services, PeerStatus::Tried);
             return Ok(peer);
         }
-        let current_count = {
-            let mut peer_manager = self.db.lock().await;
-            peer_manager.num_unbanned().await?
-        };
-        if current_count < 1 {
-            self.dialog.send_warning(Warning::EmptyPeerDatabase);
-            self.bootstrap().await?;
-        }
         let mut peer_manager = self.db.lock().await;
         let mut tries = 0;
         let desired_status = PeerStatus::random();
@@ -359,35 +352,51 @@ impl<P: PeerStore> PeerMap<P> {
         }
     }
 
-    async fn bootstrap(&mut self) -> Result<(), PeerManagerError<P::Error>> {
-        use crate::network::dns::Dns;
-        use std::net::IpAddr;
-        crate::log!(self.dialog, "Bootstrapping peers with DNS");
+    pub(crate) async fn bootstrap(&mut self) -> Result<(), PeerManagerError<P::Error>> {
         let mut db_lock = self.db.lock().await;
-        let new_peers = Dns::new(self.network, self.dns_resolver)
-            .bootstrap()
-            .await
-            .into_iter()
-            .map(|ip| match ip {
-                IpAddr::V4(ip) => AddrV2::Ipv4(ip),
-                IpAddr::V6(ip) => AddrV2::Ipv6(ip),
-            })
-            .collect::<Vec<AddrV2>>();
-        crate::log!(
-            self.dialog,
-            format!("Adding {} sourced from DNS", new_peers.len())
-        );
-        for peer in new_peers {
-            db_lock
-                .update(PersistedPeer::new(
-                    peer,
-                    default_port_from_network(&self.network),
-                    ServiceFlags::NONE,
-                    PeerStatus::Gossiped,
-                ))
+        let current_count = db_lock.num_unbanned().await?;
+        if current_count == 0 && self.whitelist.is_empty() {
+            crate::log!(self.dialog, "Bootstrapping peers with DNS");
+            let new_peers = Dns::new(self.network, self.dns_config.resolver)
+                .bootstrap()
                 .await
-                .map_err(PeerManagerError::Database)?;
+                .into_iter()
+                .map(|ip| match ip {
+                    IpAddr::V4(ip) => AddrV2::Ipv4(ip),
+                    IpAddr::V6(ip) => AddrV2::Ipv6(ip),
+                })
+                .collect::<Vec<AddrV2>>();
+            crate::log!(
+                self.dialog,
+                format!("Adding {} sourced from DNS", new_peers.len())
+            );
+            for peer in new_peers {
+                db_lock
+                    .update(PersistedPeer::new(
+                        peer,
+                        default_port_from_network(&self.network),
+                        ServiceFlags::NONE,
+                        PeerStatus::Gossiped,
+                    ))
+                    .await
+                    .map_err(PeerManagerError::Database)?;
+            }
+            return Ok(());
         }
+        if self.dns_config.force_seeding {
+            crate::log!(self.dialog, "Using DNS as peer source");
+            let new_peers = Dns::random(self.network, self.dns_config.resolver)
+                .bootstrap()
+                .await
+                .into_iter()
+                .map(From::from);
+            crate::log!(
+                self.dialog,
+                format!("Adding {} sourced from DNS", new_peers.len())
+            );
+            self.whitelist.extend(new_peers);
+            return Ok(());
+        };
         Ok(())
     }
 }

--- a/src/node.rs
+++ b/src/node.rs
@@ -69,7 +69,7 @@ impl<H: HeaderStore, P: PeerStore> Node<H, P> {
         let NodeConfig {
             required_peers,
             white_list,
-            dns_resolver,
+            dns_config,
             addresses,
             data_path: _,
             header_checkpoint,
@@ -102,7 +102,7 @@ impl<H: HeaderStore, P: PeerStore> Node<H, P> {
             target_peer_size,
             peer_timeout_config,
             Arc::clone(&height_monitor),
-            dns_resolver,
+            dns_config,
         )));
         // Prepare the header checkpoints for the chain source
         let mut checkpoints = HeaderCheckpoints::new(&network);
@@ -149,6 +149,10 @@ impl<H: HeaderStore, P: PeerStore> Node<H, P> {
             )
         );
         self.fetch_headers().await?;
+        {
+            let mut map = self.peer_map.lock().await;
+            map.bootstrap().await?;
+        }
         let mut last_block = LastBlockMonitor::new();
         let mut peer_recv = self.peer_recv.lock().await;
         let mut client_recv = self.client_recv.lock().await;


### PR DESCRIPTION
Presumably, some end-users of this crate will download network data infrequently. This means the node may have to iterate through a high number of stale peers within the peer store, which ultimately leads to a poor user experience. The DNS seeders are acting as always-on network crawlers. If a developer is comfortable with trusting these seeders, they can provide high quality potential connections. In my opinion this isn't much of a privacy tradeoff, as the DNS resolver only knows the user is interested in the bitcoin network. This is, however, a significant trust tradeoff, as now the DNS seeders are used as a source-of-truth for good bitcoin nodes.

Guidance on if this feature should be recommended or not depends on some network analysis. @nyonson if your research finds that the proportion of filter-serving nodes _listening_ for inbound connections is low enough, this would be okay to promote to end-developers. On the other hand, if the network is reasonably available to serve filters, this could be used in special cases where we don't expect the node to shut down frequently.

This is controversial in general, so this will never be a default.

Closes #368 