### PR TITLE
Make module errors ergonomic in `network`

### DIFF
--- a/src/network/outbound_messages.rs
+++ b/src/network/outbound_messages.rs
@@ -121,7 +121,7 @@ impl MessageGenerator {
 }
 
 fn serialize_network_message(message: NetworkMessage) -> Result<Vec<u8>, PeerError> {
-    bip324::serde::serialize(message).map_err(|_| PeerError::MessageSerialization)
+    bip324::serde::serialize(message).map_err(From::from)
 }
 
 fn encrypt_plaintext(
@@ -130,7 +130,7 @@ fn encrypt_plaintext(
 ) -> Result<Vec<u8>, PeerError> {
     encryptor
         .encrypt_packet(&plaintext, None, PacketType::Genuine)
-        .map_err(|_| PeerError::MessageEncryption)
+        .map_err(From::from)
 }
 
 fn make_version(port: Option<u16>, network: &Network) -> VersionMessage {

--- a/src/network/parsers.rs
+++ b/src/network/parsers.rs
@@ -5,7 +5,7 @@ use bitcoin::p2p::message::RawNetworkMessage;
 use bitcoin::Network;
 use tokio::io::AsyncReadExt;
 
-use super::error::PeerReadError;
+use super::error::ReaderError;
 use super::V1Header;
 
 const MAX_MESSAGE_BYTES: u32 = 1024 * 1024 * 32;
@@ -16,30 +16,21 @@ pub(crate) enum MessageParser<R: AsyncReadExt + Send + Sync + Unpin> {
 }
 
 impl<R: AsyncReadExt + Send + Sync + Unpin> MessageParser<R> {
-    pub async fn read_message(&mut self) -> Result<Option<NetworkMessage>, PeerReadError> {
+    pub async fn read_message(&mut self) -> Result<Option<NetworkMessage>, ReaderError> {
         match self {
             MessageParser::V2(stream, decryptor) => {
                 let mut len_buf = [0; 3];
-                let _ = stream
-                    .read_exact(&mut len_buf)
-                    .await
-                    .map_err(|_| PeerReadError::ReadBuffer)?;
+                let _ = stream.read_exact(&mut len_buf).await?;
                 let message_len = decryptor.decypt_len(len_buf);
                 if message_len > MAX_MESSAGE_BYTES as usize {
-                    return Err(PeerReadError::TooManyMessages);
+                    return Err(ReaderError::MessageTooLarge);
                 }
                 let mut response_message = vec![0; message_len];
-                let _ = stream
-                    .read_exact(&mut response_message)
-                    .await
-                    .map_err(|_| PeerReadError::ReadBuffer)?;
-                let msg = decryptor
-                    .decrypt_payload(&response_message, None)
-                    .map_err(|_| PeerReadError::DecryptionFailed)?;
+                let _ = stream.read_exact(&mut response_message).await?;
+                let msg = decryptor.decrypt_payload(&response_message, None)?;
                 match msg.packet_type() {
                     PacketType::Genuine => {
-                        let parsed = bip324::serde::deserialize(msg.contents())
-                            .map_err(|_| PeerReadError::Deserialization)?;
+                        let parsed = bip324::serde::deserialize(msg.contents())?;
                         Ok(Some(parsed))
                     }
                     PacketType::Decoy => Ok(None),
@@ -47,29 +38,20 @@ impl<R: AsyncReadExt + Send + Sync + Unpin> MessageParser<R> {
             }
             MessageParser::V1(stream, network) => {
                 let mut message_buf = vec![0_u8; 24];
-                let _ = stream
-                    .read_exact(&mut message_buf)
-                    .await
-                    .map_err(|_| PeerReadError::ReadBuffer)?;
-                let header: V1Header = deserialize_partial(&message_buf)
-                    .map_err(|_| PeerReadError::Deserialization)?
-                    .0;
+                let _ = stream.read_exact(&mut message_buf).await?;
+                let header: V1Header = deserialize_partial(&message_buf)?.0;
                 // Nonsense for our network
                 if header.magic != network.magic() {
-                    return Err(PeerReadError::Deserialization);
+                    return Err(ReaderError::InvalidDeserialization);
                 }
                 // Message is too long
                 if header.length > MAX_MESSAGE_BYTES {
-                    return Err(PeerReadError::Deserialization);
+                    return Err(ReaderError::MessageTooLarge);
                 }
                 let mut contents_buf = vec![0_u8; header.length as usize];
-                let _ = stream
-                    .read_exact(&mut contents_buf)
-                    .await
-                    .map_err(|_| PeerReadError::ReadBuffer)?;
+                let _ = stream.read_exact(&mut contents_buf).await?;
                 message_buf.extend_from_slice(&contents_buf);
-                let message: RawNetworkMessage =
-                    deserialize(&message_buf).map_err(|_| PeerReadError::Deserialization)?;
+                let message: RawNetworkMessage = deserialize(&message_buf)?;
                 Ok(Some(message.into_payload()))
             }
         }


### PR DESCRIPTION
There are a million pointless `map_err` around the module that I can only assume I added out of laziness. This module has grown quiet a bit, so the errors should be easier to work with. I don't implement `source` here because these are not used in a backtrace. Instead they are used to drive control flow.