### PR TITLE
Fix weekly job

### DIFF
--- a/.github/workflows/weekly-sync-test.yml
+++ b/.github/workflows/weekly-sync-test.yml
@@ -14,5 +14,5 @@ jobs:
       - uses: actions/checkout@v4
       - uses: extractions/setup-just@v3
       - uses: actions-rust-lang/setup-rust-toolchain@v1
-      - run: just example mainnet
+      - run: just example bitcoin
         timeout-minutes: 60


### PR DESCRIPTION
Example is called "bitcoin" to stay consistent with `rust-bitcoin` nomenclature 