### PR TITLE
Remove `GetBlockConfig` for `BlockHash`

### DIFF
--- a/src/channel_messages.rs
+++ b/src/channel_messages.rs
@@ -21,7 +21,7 @@ pub(crate) enum MainThreadMessage {
     GetHeaders(GetHeaderConfig),
     GetFilterHeaders(GetCFHeaders),
     GetFilters(GetCFilters),
-    GetBlock(GetBlockConfig),
+    GetBlock(BlockHash),
     Disconnect,
     BroadcastPending,
     Verack,
@@ -37,8 +37,8 @@ impl MainThreadMessage {
             MainThreadMessage::GetFilters(_) => {
                 Some((TimeSensitiveId::C_FILTER_MSG, Instant::now()))
             }
-            MainThreadMessage::GetBlock(conf) => {
-                let id = conf.locator.to_raw_hash().to_byte_array();
+            MainThreadMessage::GetBlock(hash) => {
+                let id = hash.to_raw_hash().to_byte_array();
                 Some((TimeSensitiveId::from_slice(id), Instant::now()))
             }
             _ => None,
@@ -50,11 +50,6 @@ impl MainThreadMessage {
 pub struct GetHeaderConfig {
     pub locators: Vec<BlockHash>,
     pub stop_hash: Option<BlockHash>,
-}
-
-#[derive(Debug, Clone)]
-pub struct GetBlockConfig {
-    pub locator: BlockHash,
 }
 
 pub(crate) struct PeerThreadMessage {

--- a/src/network/outbound_messages.rs
+++ b/src/network/outbound_messages.rs
@@ -17,7 +17,7 @@ use bitcoin::{
     BlockHash, Network, Transaction, Wtxid,
 };
 
-use crate::{channel_messages::GetBlockConfig, prelude::default_port_from_network};
+use crate::prelude::default_port_from_network;
 
 use super::{error::PeerError, KYOTO_VERSION, PROTOCOL_VERSION, RUST_BITCOIN_VERSION};
 
@@ -92,8 +92,8 @@ impl MessageGenerator {
         self.serialize(msg)
     }
 
-    pub(crate) fn block(&mut self, config: GetBlockConfig) -> Result<Vec<u8>, PeerError> {
-        let inv = get_block_from_cfg(config);
+    pub(crate) fn block(&mut self, hash: BlockHash) -> Result<Vec<u8>, PeerError> {
+        let inv = get_block_from_cfg(hash);
         let msg = NetworkMessage::GetData(vec![inv]);
         self.serialize(msg)
     }
@@ -164,10 +164,10 @@ fn make_version(port: Option<u16>, network: &Network) -> VersionMessage {
     }
 }
 
-fn get_block_from_cfg(config: GetBlockConfig) -> Inventory {
+fn get_block_from_cfg(hash: BlockHash) -> Inventory {
     if cfg!(feature = "filter-control") {
-        Inventory::WitnessBlock(config.locator)
+        Inventory::WitnessBlock(hash)
     } else {
-        Inventory::Block(config.locator)
+        Inventory::Block(hash)
     }
 }

--- a/src/node.rs
+++ b/src/node.rs
@@ -32,9 +32,7 @@ use crate::{
 };
 
 use super::{
-    channel_messages::{
-        GetBlockConfig, GetHeaderConfig, MainThreadMessage, PeerMessage, PeerThreadMessage,
-    },
+    channel_messages::{GetHeaderConfig, MainThreadMessage, PeerMessage, PeerThreadMessage},
     client::Client,
     config::NodeConfig,
     dialog::Dialog,
@@ -614,9 +612,7 @@ impl<H: HeaderStore, P: PeerStore> Node<H, P> {
             return match next_block_hash {
                 Some(block_hash) => {
                     crate::log!(self.dialog, format!("Next block in queue: {}", block_hash));
-                    Some(MainThreadMessage::GetBlock(GetBlockConfig {
-                        locator: block_hash,
-                    }))
+                    Some(MainThreadMessage::GetBlock(block_hash))
                 }
                 None => None,
             };


### PR DESCRIPTION
The `GetBlockConfig` only wraps a `BlockHash` that should be requested. This is currently a pretty useless indirection, so it should be removed until there is reasonable motivation to change how blocks are requested by the main loop.