### PR TITLE
Do not compute difficulty adjustment on `Testnet4`

### DIFF
--- a/src/chain/graph.rs
+++ b/src/chain/graph.rs
@@ -324,6 +324,12 @@ impl BlockTree {
     }
 
     fn compute_next_work_required(&self, new_height: Height) -> Option<CompactTarget> {
+        // Do not audit the diffulty for `Testnet`. Auditing the difficulty properly for a testnet
+        // will result in convoluted logic. This is a critical code block for mainnet and should be
+        // as readable as possible
+        if self.network.params().allow_min_difficulty_blocks {
+            return None;
+        }
         let adjustment_period =
             Height::from_u64_checked(self.network.params().difficulty_adjustment_interval())?;
         let epoch_start = new_height.checked_sub(adjustment_period)?;


### PR DESCRIPTION
Raised by: https://github.com/bitcoindevkit/bdk-cli/pull/197

Users of `Testnet4` will run into problems when loading headers from the database, as the network allows for minimum difficulty blocks. Instead of adding logic for the header timestamps just for the sake of `Testnet4`, I am opting to simply ignore the difficutly adjustment. This boolean does not evaluate to `true` on `Bitcoin`, which is easily verified in `rust-bitcoin`.

Notably `Signet` does not allow minimum difficulty blocks, so difficulty adjustment logic is still tested by a testnet as well as mainnet. This is only dropping `Testnet4`