### PR TITLE
DNS bootstrap at the start of node lifecycle

### DIFF
--- a/src/node.rs
+++ b/src/node.rs
@@ -152,6 +152,10 @@ impl<H: HeaderStore, P: PeerStore> Node<H, P> {
                 self.required_peers
             )
         );
+        {
+            let mut peer_map = self.peer_map.lock().await;
+            peer_map.bootstrap().await?;
+        }
         self.fetch_headers().await?;
         let mut last_block = LastBlockMonitor::new();
         let mut peer_recv = self.peer_recv.lock().await;


### PR DESCRIPTION
When trying to select a random peer from the database, if the database happens to have 0 peers available, and there are no trusted peers, then the DNS bootstrap occurs. This special logic does not need to occur when selecting a peer to connect to. Instead, the node may boostrap if necessary at the start of the process, given there are no peers available.