### PR TITLE
Make `lookup_host` and DNS queries more robust.

### DIFF
--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -95,10 +95,12 @@ pub(crate) fn default_port_from_network(network: &Network) -> u16 {
     }
 }
 
-pub(crate) fn encode_qname(domain: &str, filter: &str) -> Vec<u8> {
+pub(crate) fn encode_qname(domain: &str, filter: Option<&str>) -> Vec<u8> {
     let mut qname = Vec::new();
-    qname.push(filter.len() as u8);
-    qname.extend(filter.as_bytes());
+    if let Some(filter) = filter {
+        qname.push(filter.len() as u8);
+        qname.extend(filter.as_bytes());
+    }
     for label in domain.split('.') {
         qname.push(label.len() as u8);
         qname.extend(label.as_bytes());


### PR DESCRIPTION
I had some unfortunate experience with trying to use DNS to bootstrap on both Testnet4 and Signet recently. The bootstrapping phase was returning no results for both networks, and after some experimenting in the terminal I realized the filtering is not returning any results, so:

`dig seed.signet.bitcoin.sprovoost.nl` returns results but `dig x849.seed.signet.bitcoin.sprovoost.nl` does not.

On Bitcoin there is a similar trend for some of the seeders, but others are still returning results. There has been no change to the seeder repository.

As far as the change, I add one additional query with no service filters to ensure the result will return at least some nodes to try to crawl the network.