### PR TITLE
lib: Hide `NodeState` as internal

### DIFF
--- a/example/bitcoin.rs
+++ b/example/bitcoin.rs
@@ -51,7 +51,7 @@ async fn main() {
             event = event_rx.recv() => {
                 if let Some(event) = event {
                     match event {
-                        Event::Synced(update) => {
+                        Event::FiltersSynced(update) => {
                             tracing::info!("Chain tip: {}",update.tip().hash);
                             // Request information from the node
                             let fee = requester.broadcast_min_feerate().await.unwrap();

--- a/example/signet.rs
+++ b/example/signet.rs
@@ -77,7 +77,7 @@ async fn main() {
                                 break;
                             }
                         },
-                        Event::Synced(_) => break,
+                        Event::FiltersSynced(_) => break,
                         _ => (),
                     }
                 }

--- a/src/chain/block_queue.rs
+++ b/src/chain/block_queue.rs
@@ -76,6 +76,7 @@ impl BlockQueue {
         ProcessBlockResponse::UnknownHash
     }
 
+    #[allow(unused)]
     pub(crate) fn complete(&self) -> bool {
         self.want.is_none() && self.queue.is_empty()
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,7 @@
 //!     loop {
 //!         if let Some(event) = event_rx.recv().await {
 //!             match event {
-//!                 Event::Synced(_) => {
+//!                 Event::FiltersSynced(_) => {
 //!                     tracing::info!("Sync complete!");
 //!                     break;
 //!                 },
@@ -343,9 +343,9 @@ pub enum PeerStoreSizeConfig {
     Limit(u32),
 }
 
-/// The state of the node with respect to connected peers.
+// The state of the node with respect to connected peers.
 #[derive(Debug, Clone, Copy)]
-pub enum NodeState {
+enum NodeState {
     /// We are behind on block headers according to our peers.
     Behind,
     /// We may start downloading compact block filter headers.
@@ -354,8 +354,6 @@ pub enum NodeState {
     FilterHeadersSynced,
     /// We may start asking for blocks with matches.
     FiltersSynced,
-    /// We found all known transactions to the wallet.
-    TransactionsSynced,
 }
 
 impl core::fmt::Display for NodeState {
@@ -371,7 +369,6 @@ impl core::fmt::Display for NodeState {
                 write!(f, "Requesting compact block filters.")
             }
             NodeState::FiltersSynced => write!(f, "Downloading blocks with relevant transactions."),
-            NodeState::TransactionsSynced => write!(f, "Fully synced to the highest block."),
         }
     }
 }

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -6,7 +6,7 @@ use tokio::sync::oneshot;
 use crate::IndexedFilter;
 use crate::{
     chain::{checkpoints::HeaderCheckpoint, IndexedHeader},
-    IndexedBlock, NodeState, TrustedPeer, TxBroadcast,
+    IndexedBlock, TrustedPeer, TxBroadcast,
 };
 
 use super::error::{FetchBlockError, FetchHeaderError};
@@ -14,8 +14,6 @@ use super::error::{FetchBlockError, FetchHeaderError};
 /// Informational messages emitted by a node
 #[derive(Debug, Clone)]
 pub enum Info {
-    /// The current state of the node in the syncing process.
-    StateChange(NodeState),
     /// The node was able to successfully complete a version handshake.
     SuccessfulHandshake,
     /// The node is connected to all required peers.
@@ -40,7 +38,6 @@ pub enum Info {
 impl core::fmt::Display for Info {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
-            Info::StateChange(s) => write!(f, "{s}"),
             Info::SuccessfulHandshake => write!(f, "Successful version handshake with a peer"),
             Info::TxGossiped(txid) => write!(f, "Transaction gossiped: {txid}"),
             Info::ConnectionsMet => write!(f, "Required connections met"),
@@ -62,7 +59,7 @@ pub enum Event {
     /// This is due to block filters having a non-zero false-positive rate when compressing data.
     Block(IndexedBlock),
     /// The node is fully synced, having scanned the requested range.
-    Synced(SyncUpdate),
+    FiltersSynced(SyncUpdate),
     /// Blocks were reorganized out of the chain.
     BlocksDisconnected {
         /// Blocks that were accepted to the chain of most work in ascending order by height.

--- a/tests/core.rs
+++ b/tests/core.rs
@@ -96,7 +96,7 @@ async fn sync_assert(best: &bitcoin::BlockHash, channel: &mut UnboundedReceiver<
     loop {
         tokio::select! {
             event = channel.recv() => {
-                if let Some(Event::Synced(update)) = event {
+                if let Some(Event::FiltersSynced(update)) = event {
                     assert_eq!(update.tip().hash, *best);
                     println!("Correct sync");
                     break;
@@ -159,7 +159,7 @@ async fn live_reorg() {
                 assert_eq!(blocks.first().unwrap().header.block_hash(), old_best);
                 assert_eq!(old_height as u32, blocks.first().unwrap().height);
             }
-            kyoto::messages::Event::Synced(update) => {
+            kyoto::messages::Event::FiltersSynced(update) => {
                 assert_eq!(update.tip().hash, best);
                 requester.shutdown().unwrap();
                 break;
@@ -209,7 +209,7 @@ async fn live_reorg_additional_sync() {
                 assert_eq!(blocks.first().unwrap().header.block_hash(), old_best);
                 assert_eq!(old_height as u32, blocks.first().unwrap().height);
             }
-            kyoto::messages::Event::Synced(update) => {
+            kyoto::messages::Event::FiltersSynced(update) => {
                 assert_eq!(update.tip().hash, best);
                 break;
             }
@@ -300,7 +300,7 @@ async fn stop_reorg_resync() {
                 assert_eq!(blocks.first().unwrap().header.block_hash(), old_best);
                 assert_eq!(old_height as u32, blocks.first().unwrap().height);
             }
-            kyoto::messages::Event::Synced(update) => {
+            kyoto::messages::Event::FiltersSynced(update) => {
                 println!("Done");
                 assert_eq!(update.tip().hash, best);
                 break;
@@ -378,7 +378,7 @@ async fn stop_reorg_two_resync() {
                 assert_eq!(blocks.last().unwrap().header.block_hash(), old_best);
                 assert_eq!(old_height as u32, blocks.last().unwrap().height);
             }
-            kyoto::messages::Event::Synced(update) => {
+            kyoto::messages::Event::FiltersSynced(update) => {
                 println!("Done");
                 assert_eq!(update.tip().hash, best);
                 break;
@@ -458,7 +458,7 @@ async fn stop_reorg_start_on_orphan() {
                 assert_eq!(blocks.first().unwrap().header.block_hash(), old_best);
                 assert_eq!(old_height as u32, blocks.first().unwrap().height);
             }
-            kyoto::messages::Event::Synced(update) => {
+            kyoto::messages::Event::FiltersSynced(update) => {
                 println!("Done");
                 assert_eq!(update.tip().hash, best);
                 break;


### PR DESCRIPTION
This enum is a bit of API creep as this is really used as an internal driver. Users are able to request blocks at their own discretion, and the previous `Synced` event might be emitted even when the user has blocks they are interested. The most information we can disclose is that the filters have been synced to the network. Everything else is emitted via `Info` or `Event`

This allows future models of the state machine to not break existing users.