### PR TITLE
Rename `NodeBuilder` to `Builder`

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@ just example
 
 ## Getting Started
 
-It is recommended to walk through the [Signet example code](./example/signet.rs). Unlike usual clients that source data from the blockchain, there are two components to the CBF system. There is a "node" that fetches data on behalf of a user, and a "client" that receives data, logs, and warnings from the node. The client may also interact with the node by sending transactions to broadcast or new scripts. This crate allows a highly configurable node construction, so your app may optimize for the desired speed, privacy, and preferences.
+It is recommended to walk through the [Signet example code](./example/signet.rs). Unlike usual clients that source data from the blockchain, there are two components to the CBF system. There is a "node" that fetches data on behalf of a user, and a "client" that receives data, logs, and warnings from the node. The client may also interact with the node by sending transactions to broadcast or fetching metadata. This crate allows a highly configurable node construction, so your app may optimize for the desired speed, privacy, and preferences.
 
-See the [docs](https://docs.rs/kyoto-cbf) for more details on the `NodeBuilder`, `Node`, `Client`, and more.
+See the [docs](https://docs.rs/kyoto-cbf) for more details on the `Builder`, `Node`, `Client`, and more.
 
 ### BDK
 

--- a/example/bitcoin.rs
+++ b/example/bitcoin.rs
@@ -1,7 +1,7 @@
 //! Sync a simple script with the Bitcoin network. This example is intended to demonstrate the
 //! expected sync time on your machine and in your region.
 
-use kyoto::builder::NodeBuilder;
+use kyoto::builder::Builder;
 use kyoto::{lookup_host, Client, Event, HeaderCheckpoint, Network, ScriptBuf};
 use std::collections::HashSet;
 use std::net::Ipv4Addr;
@@ -22,7 +22,7 @@ async fn main() {
     addresses.insert(address);
     let seeds = lookup_host("dnsseed.bitcoin.dashjr-list-of-p2p-nodes.us", HOST_ADDR).await;
     // Create a new node builder
-    let builder = NodeBuilder::new(NETWORK);
+    let builder = Builder::new(NETWORK);
     // Add node preferences and build the node/client
     let (node, client) = builder
         // The number of connections we would like to maintain

--- a/example/signet.rs
+++ b/example/signet.rs
@@ -2,7 +2,7 @@
 //! and request a block be downloaded.
 
 use kyoto::messages::Event;
-use kyoto::{builder::NodeBuilder, chain::checkpoints::HeaderCheckpoint, Client};
+use kyoto::{builder::Builder, chain::checkpoints::HeaderCheckpoint, Client};
 use kyoto::{Address, BlockHash, Network};
 use std::collections::HashSet;
 use std::str::FromStr;
@@ -29,7 +29,7 @@ async fn main() {
     let mut addresses = HashSet::new();
     addresses.insert(address);
     // Create a new node builder
-    let builder = NodeBuilder::new(NETWORK);
+    let builder = Builder::new(NETWORK);
     // Add node preferences and build the node/client
     let (node, client) = builder
         // Only scan blocks strictly after a checkpoint

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -32,21 +32,21 @@ const MAX_PEERS: u8 = 15;
 /// ```rust
 /// use std::net::{IpAddr, Ipv4Addr};
 /// use std::collections::HashSet;
-/// use kyoto::{NodeBuilder, Network};
+/// use kyoto::{Builder, Network};
 ///
 /// let host = (IpAddr::from(Ipv4Addr::new(0, 0, 0, 0)), None);
-/// let builder = NodeBuilder::new(Network::Regtest);
+/// let builder = Builder::new(Network::Regtest);
 /// let (node, client) = builder
 ///     .add_peers(vec![host.into()])
 ///     .build()
 ///     .unwrap();
 /// ```
-pub struct NodeBuilder {
+pub struct Builder {
     config: NodeConfig,
     network: Network,
 }
 
-impl NodeBuilder {
+impl Builder {
     /// Create a new [`NodeBuilder`].
     pub fn new(network: Network) -> Self {
         Self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@
 //! # Example usage
 //!
 //! ```no_run
-//! use kyoto::{NodeBuilder, Event, Client, Network, BlockHash};
+//! use kyoto::{Builder, Event, Client, Network, BlockHash};
 //!
 //! #[tokio::main]
 //! async fn main() {
@@ -16,7 +16,7 @@
 //!     let subscriber = tracing_subscriber::FmtSubscriber::new();
 //!     tracing::subscriber::set_global_default(subscriber).unwrap();
 //!     // Create a new node builder
-//!     let builder = NodeBuilder::new(Network::Signet);
+//!     let builder = Builder::new(Network::Signet);
 //!     // Add node preferences and build the node/client
 //!     let (node, client) = builder
 //!         // The number of connections we would like to maintain
@@ -97,7 +97,7 @@ pub use tokio::sync::mpsc::UnboundedReceiver;
 
 #[doc(inline)]
 pub use {
-    crate::builder::NodeBuilder,
+    crate::builder::Builder,
     crate::client::{Client, Requester},
     crate::error::{ClientError, NodeError},
     crate::messages::{Event, Info, Progress, RejectPayload, SyncUpdate, Warning},

--- a/tests/core.rs
+++ b/tests/core.rs
@@ -56,7 +56,7 @@ fn new_node(
     let host = (IpAddr::V4(*socket_addr.ip()), Some(socket_addr.port()));
     let mut trusted: TrustedPeer = host.into();
     trusted.set_services(ServiceFlags::P2P_V2);
-    let mut builder = kyoto::builder::NodeBuilder::new(bitcoin::Network::Regtest);
+    let mut builder = kyoto::builder::Builder::new(bitcoin::Network::Regtest);
     if let Some(checkpoint) = checkpoint {
         builder = builder.after_checkpoint(checkpoint);
     }


### PR DESCRIPTION
I think this was suggested by @nyonson a while back and I forgot about it. The `Node` part is implied, as the library only does one thing. Simplify the naming, also this will show higher on docs.rs