### PR TITLE
Bump MSRV in manifest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/2140-dev/kyoto"
 readme = "README.md"
 keywords = ["bitcoin", "cryptography", "network", "peer-to-peer"]
 categories = ["cryptography::cryptocurrencies"]
-rust-version = "1.63.0"
+rust-version = "1.74.0"
 
 [dependencies]
 bitcoin = { version = "0.32.7", default-features = false, features = [

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Kyoto integrates well with the Bitcoin Dev Kit (BDK) ecosystem.
 
 ## Minimum Supported Rust Version (MSRV) Policy
 
-The `bip157` core library with default features supports an MSRV of Rust 1.63.
+The `bip157` core library with default features supports an MSRV of Rust 1.74.
 
 ## Contributing
 


### PR DESCRIPTION
How do we know what version we can increase `tokio` to @nyonson? I think I will leave this one penultimate release, not the next one. Just throwing this up to start a discussion.