### PR TITLE
Remove the `PeerStore` generic

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -4,21 +4,18 @@ use std::{path::PathBuf, time::Duration};
 use bitcoin::Network;
 
 use super::{client::Client, config::NodeConfig, node::Node};
+use crate::chain::checkpoints::HeaderCheckpoint;
 #[cfg(feature = "rusqlite")]
 use crate::db::error::SqlInitializationError;
 #[cfg(feature = "rusqlite")]
 use crate::db::sqlite::{headers::SqliteHeaderDb, peers::SqlitePeerDb};
 use crate::network::dns::{DnsResolver, DNS_RESOLVER_PORT};
 use crate::network::ConnectionType;
-use crate::{
-    chain::checkpoints::HeaderCheckpoint,
-    db::traits::{HeaderStore, PeerStore},
-};
 use crate::{PeerStoreSizeConfig, TrustedPeer};
 
 #[cfg(feature = "rusqlite")]
 /// The default node returned from the [`Builder`].
-pub type NodeDefault = Node<SqliteHeaderDb, SqlitePeerDb>;
+pub type NodeDefault = Node<SqliteHeaderDb>;
 
 const MIN_PEERS: u8 = 1;
 const MAX_PEERS: u8 = 15;
@@ -178,19 +175,5 @@ impl Builder {
             peer_store,
             header_store,
         ))
-    }
-
-    /// Consume the node builder by using custom database implementations, receiving a [`Node`] and [`Client`].
-    pub fn build_with_databases<H: HeaderStore + 'static, P: PeerStore + 'static>(
-        &mut self,
-        peer_store: P,
-        header_store: H,
-    ) -> (Node<H, P>, Client) {
-        Node::new(
-            self.network,
-            core::mem::take(&mut self.config),
-            peer_store,
-            header_store,
-        )
     }
 }

--- a/src/db/traits.rs
+++ b/src/db/traits.rs
@@ -6,7 +6,7 @@ use bitcoin::{block::Header, BlockHash};
 
 use crate::prelude::FutureResult;
 
-use super::{BlockHeaderChanges, PersistedPeer};
+use super::BlockHeaderChanges;
 
 /// Methods required to persist the chain of block headers.
 pub trait HeaderStore: Debug + Send + Sync {
@@ -37,63 +37,10 @@ pub trait HeaderStore: Debug + Send + Sync {
     fn header_at(&mut self, height: u32) -> FutureResult<'_, Option<Header>, Self::Error>;
 }
 
-/// Methods that define a list of peers on the Bitcoin P2P network.
-pub trait PeerStore: Debug + Send + Sync {
-    /// Errors that may occur within a [`PeerStore`].
-    type Error: Debug + Display;
-    /// Add a peer to the database, defining if it should be replaced or not.
-    fn update(&mut self, peer: PersistedPeer) -> FutureResult<'_, (), Self::Error>;
-
-    /// Get any peer from the database, selected at random. If no peers exist, an error is thrown.
-    fn random(&mut self) -> FutureResult<'_, PersistedPeer, Self::Error>;
-
-    /// The number of peers in the database that are not marked as banned.
-    fn num_unbanned(&mut self) -> FutureResult<'_, u32, Self::Error>;
-}
-
 #[cfg(test)]
 mod test {
     use super::*;
     use std::convert::Infallible;
-
-    /// Errors for the [`PeerStore`](crate) of unit type.
-    #[derive(Debug)]
-    pub enum UnitPeerStoreError {
-        /// There were no peers found.
-        NoPeers,
-    }
-
-    impl core::fmt::Display for UnitPeerStoreError {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-            match self {
-                UnitPeerStoreError::NoPeers => write!(f, "no peers in unit database."),
-            }
-        }
-    }
-
-    impl PeerStore for () {
-        type Error = UnitPeerStoreError;
-        fn update(&mut self, _peer: PersistedPeer) -> FutureResult<'_, (), Self::Error> {
-            async fn do_update() -> Result<(), UnitPeerStoreError> {
-                Ok(())
-            }
-            Box::pin(do_update())
-        }
-
-        fn random(&mut self) -> FutureResult<'_, PersistedPeer, Self::Error> {
-            async fn do_random() -> Result<PersistedPeer, UnitPeerStoreError> {
-                Err(UnitPeerStoreError::NoPeers)
-            }
-            Box::pin(do_random())
-        }
-
-        fn num_unbanned(&mut self) -> FutureResult<'_, u32, Self::Error> {
-            async fn do_num_unbanned() -> Result<u32, UnitPeerStoreError> {
-                Ok(0)
-            }
-            Box::pin(do_num_unbanned())
-        }
-    }
 
     impl HeaderStore for () {
         type Error = Infallible;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,7 +88,7 @@ pub use chain::checkpoints::HeaderCheckpoint;
 pub use db::sqlite::{headers::SqliteHeaderDb, peers::SqlitePeerDb};
 
 #[doc(inline)]
-pub use db::traits::{HeaderStore, PeerStore};
+pub use db::traits::HeaderStore;
 
 #[doc(inline)]
 pub use tokio::sync::mpsc::Receiver;

--- a/src/network/peer.rs
+++ b/src/network/peer.rs
@@ -22,7 +22,7 @@ use crate::{
     db::PersistedPeer,
     dialog::Dialog,
     messages::Warning,
-    Info, PeerStore,
+    Info, SqlitePeerDb,
 };
 
 use super::{
@@ -36,20 +36,20 @@ use super::{
 const LOOP_TIMEOUT: Duration = Duration::from_secs(2);
 const V2_HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(4);
 
-pub(crate) struct Peer<P: PeerStore + 'static> {
+pub(crate) struct Peer {
     nonce: PeerId,
     main_thread_sender: Sender<PeerThreadMessage>,
     main_thread_recv: Receiver<MainThreadMessage>,
     network: Network,
     services: ServiceFlags,
     dialog: Arc<Dialog>,
-    db: Arc<Mutex<P>>,
+    db: Arc<Mutex<SqlitePeerDb>>,
     timeout_config: PeerTimeoutConfig,
     message_state: MessageState,
     tx_queue: Arc<Mutex<BroadcastQueue>>,
 }
 
-impl<P: PeerStore + 'static> Peer<P> {
+impl Peer {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         nonce: PeerId,
@@ -58,7 +58,7 @@ impl<P: PeerStore + 'static> Peer<P> {
         main_thread_recv: Receiver<MainThreadMessage>,
         services: ServiceFlags,
         dialog: Arc<Dialog>,
-        db: Arc<Mutex<P>>,
+        db: Arc<Mutex<SqlitePeerDb>>,
         timeout_config: PeerTimeoutConfig,
         tx_queue: Arc<Mutex<BroadcastQueue>>,
     ) -> Self {

--- a/src/node.rs
+++ b/src/node.rs
@@ -29,10 +29,10 @@ use crate::{
         error::{CFilterSyncError, HeaderSyncError},
         CFHeaderChanges, FilterCheck, HeaderChainChanges, HeightMonitor,
     },
-    db::traits::{HeaderStore, PeerStore},
+    db::traits::HeaderStore,
     error::{FetchBlockError, FetchHeaderError},
     network::{peer_map::PeerMap, LastBlockMonitor, PeerId},
-    IndexedBlock, NodeState, TxBroadcast, TxBroadcastPolicy,
+    IndexedBlock, NodeState, SqlitePeerDb, TxBroadcast, TxBroadcastPolicy,
 };
 
 use super::{
@@ -51,10 +51,10 @@ type PeerRequirement = usize;
 
 /// A compact block filter node. Nodes download Bitcoin block headers, block filters, and blocks to send relevant events to a client.
 #[derive(Debug)]
-pub struct Node<H: HeaderStore, P: PeerStore + 'static> {
+pub struct Node<H: HeaderStore> {
     state: NodeState,
     chain: Chain<H>,
-    peer_map: PeerMap<P>,
+    peer_map: PeerMap,
     required_peers: PeerRequirement,
     dialog: Arc<Dialog>,
     block_queue: BlockQueue,
@@ -62,11 +62,11 @@ pub struct Node<H: HeaderStore, P: PeerStore + 'static> {
     peer_recv: Receiver<PeerThreadMessage>,
 }
 
-impl<H: HeaderStore, P: PeerStore> Node<H, P> {
+impl<H: HeaderStore> Node<H> {
     pub(crate) fn new(
         network: Network,
         config: NodeConfig,
-        peer_store: P,
+        peer_store: SqlitePeerDb,
         header_store: H,
     ) -> (Self, Client) {
         let NodeConfig {
@@ -133,7 +133,7 @@ impl<H: HeaderStore, P: PeerStore> Node<H, P> {
     /// # Errors
     ///
     /// A node will cease running if a fatal error is encountered with either the [`PeerStore`] or [`HeaderStore`].
-    pub async fn run(mut self) -> Result<(), NodeError<H::Error, P::Error>> {
+    pub async fn run(mut self) -> Result<(), NodeError<H::Error>> {
         crate::debug!("Starting node");
         crate::debug!(format!(
             "Configured connection requirement: {} peers",
@@ -280,7 +280,7 @@ impl<H: HeaderStore, P: PeerStore> Node<H, P> {
     }
 
     // Connect to a new peer if we are not connected to enough
-    async fn dispatch(&mut self) -> Result<(), NodeError<H::Error, P::Error>> {
+    async fn dispatch(&mut self) -> Result<(), NodeError<H::Error>> {
         self.peer_map.clean().await;
         let live = self.peer_map.live();
         let required = self.next_required_peers();
@@ -401,7 +401,7 @@ impl<H: HeaderStore, P: PeerStore> Node<H, P> {
         &mut self,
         nonce: PeerId,
         version_message: VersionMessage,
-    ) -> Result<MainThreadMessage, NodeError<H::Error, P::Error>> {
+    ) -> Result<MainThreadMessage, NodeError<H::Error>> {
         if version_message.version < WTXID_VERSION {
             return Ok(MainThreadMessage::Disconnect);
         }
@@ -670,7 +670,7 @@ impl<H: HeaderStore, P: PeerStore> Node<H, P> {
     }
 
     // When the application starts, fetch any headers we know about from the database.
-    async fn fetch_headers(&mut self) -> Result<(), NodeError<H::Error, P::Error>> {
+    async fn fetch_headers(&mut self) -> Result<(), NodeError<H::Error>> {
         crate::debug!("Attempting to load headers from the database");
         self.chain
             .load_headers()

--- a/tests/core.rs
+++ b/tests/core.rs
@@ -6,8 +6,7 @@ use std::{
 
 use bip157::{
     chain::checkpoints::HeaderCheckpoint, client::Client, lookup_host, node::Node, Address,
-    BlockHash, Event, Info, ServiceFlags, SqliteHeaderDb, SqlitePeerDb, Transaction, TrustedPeer,
-    Warning,
+    BlockHash, Event, Info, ServiceFlags, SqliteHeaderDb, Transaction, TrustedPeer, Warning,
 };
 use bitcoin::{
     absolute,
@@ -52,7 +51,7 @@ fn new_node(
     socket_addr: SocketAddrV4,
     tempdir_path: PathBuf,
     checkpoint: Option<HeaderCheckpoint>,
-) -> (Node<SqliteHeaderDb, SqlitePeerDb>, Client) {
+) -> (Node<SqliteHeaderDb>, Client) {
     let host = (IpAddr::V4(*socket_addr.ip()), Some(socket_addr.port()));
     let mut trusted: TrustedPeer = host.into();
     trusted.set_services(ServiceFlags::P2P_V2);


### PR DESCRIPTION
In preparation of migrating to a new method of peer storage we can remove this generic and make SQL the only option. Naturally this will break the features flags.