### PR TITLE
Remove live config for timeout

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -1,6 +1,5 @@
 use bitcoin::{Amount, Transaction};
 use bitcoin::{BlockHash, FeeRate};
-use std::time::Duration;
 use tokio::sync::mpsc;
 use tokio::sync::mpsc::UnboundedSender;
 use tokio::sync::oneshot;
@@ -187,17 +186,6 @@ impl Requester {
     pub fn rescan(&self) -> Result<(), ClientError> {
         self.ntx
             .send(ClientMessage::Rescan)
-            .map_err(|_| ClientError::SendError)
-    }
-
-    /// Set a new connection timeout for peers to respond to messages.
-    ///
-    /// # Errors
-    ///
-    /// If the node has stopped running.
-    pub fn set_response_timeout(&self, duration: Duration) -> Result<(), ClientError> {
-        self.ntx
-            .send(ClientMessage::SetDuration(duration))
             .map_err(|_| ClientError::SendError)
     }
 

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -1,4 +1,4 @@
-use std::{collections::BTreeMap, time::Duration};
+use std::collections::BTreeMap;
 
 use bitcoin::{block::Header, p2p::message_network::RejectReason, BlockHash, FeeRate, Wtxid};
 
@@ -154,8 +154,6 @@ pub(crate) enum ClientMessage {
     Rescan,
     /// Explicitly request a block from the node.
     GetBlock(ClientRequest<BlockHash, Result<IndexedBlock, FetchBlockError>>),
-    /// Set a new connection timeout.
-    SetDuration(Duration),
     /// Add another known peer to connect to.
     AddPeer(TrustedPeer),
     /// Request the broadcast minimum fee rate.

--- a/src/network/peer_map.rs
+++ b/src/network/peer_map.rs
@@ -3,7 +3,6 @@ use std::{
     fmt::Debug,
     net::IpAddr,
     sync::Arc,
-    time::Duration,
 };
 
 use bitcoin::{
@@ -120,11 +119,6 @@ impl PeerMap {
             .values()
             .filter(|peer| !peer.handle.is_finished())
             .count()
-    }
-
-    // Set a new timeout duration
-    pub fn set_duration(&mut self, duration: Duration) {
-        self.timeout_config.response_timeout = duration;
     }
 
     // Add a new trusted peer to the whitelist

--- a/src/node.rs
+++ b/src/node.rs
@@ -239,9 +239,6 @@ impl Node {
                                     self.block_queue.add(request);
                                 }
                             },
-                            ClientMessage::SetDuration(duration) => {
-                                self.peer_map.set_duration(duration);
-                            },
                             ClientMessage::AddPeer(peer) => {
                                 self.peer_map.add_trusted_peer(peer);
                             },


### PR DESCRIPTION
There are a couple of flavors of timeout, and maybe more to come in the future. Instead of adding all of these configs to the node as it runs, it is cleaner to kill the process and start a new one.