### PR TITLE
Bump MSRV in manifest to `1.84`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/2140-dev/kyoto"
 readme = "README.md"
 keywords = ["bitcoin", "cryptography", "network", "peer-to-peer"]
 categories = ["cryptography::cryptocurrencies"]
-rust-version = "1.74.0"
+rust-version = "1.84.0"
 
 [dependencies]
 bitcoin = { version = "0.32.7", default-features = false, features = [

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Kyoto integrates well with the Bitcoin Dev Kit (BDK) ecosystem.
 
 ## Minimum Supported Rust Version (MSRV) Policy
 
-The `bip157` core library with default features supports an MSRV of Rust 1.74.
+The `bip157` core library with default features supports an MSRV of Rust 1.84.
 
 ## Contributing
 


### PR DESCRIPTION
Had a poke around the ecosystem. `ldk-node` is on `1.84` and I believe BDK will be bumping pretty agressively soon as well. Ubuntu stable is on 1.85, and one minor version older is 1.84.