### PR TITLE
Remove internal DNS implementation

### DIFF
--- a/example/bitcoin.rs
+++ b/example/bitcoin.rs
@@ -5,11 +5,9 @@ use bip157::builder::Builder;
 use bip157::chain::{BlockHeaderChanges, ChainState};
 use bip157::{lookup_host, Client, Event, HeaderCheckpoint, Network, ScriptBuf};
 use std::collections::HashSet;
-use std::net::Ipv4Addr;
 use tokio::time::Instant;
 
 const NETWORK: Network = Network::Bitcoin;
-const HOST_ADDR: Ipv4Addr = Ipv4Addr::new(1, 1, 1, 1);
 
 #[tokio::main]
 async fn main() {
@@ -21,7 +19,7 @@ async fn main() {
     let address = ScriptBuf::new_op_return(b"Kyoto light client");
     let mut addresses = HashSet::new();
     addresses.insert(address);
-    let seeds = lookup_host("dnsseed.bitcoin.dashjr-list-of-p2p-nodes.us", HOST_ADDR).await;
+    let seeds = lookup_host("seed.bitcoin.sipa.be").await;
     // Create a new node builder
     let builder = Builder::new(NETWORK);
     // Add node preferences and build the node/client

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,11 +1,10 @@
-use std::net::{IpAddr, SocketAddr};
+use std::net::SocketAddr;
 use std::{path::PathBuf, time::Duration};
 
 use bitcoin::Network;
 
 use super::{client::Client, config::NodeConfig, node::Node};
 use crate::chain::ChainState;
-use crate::network::dns::{DnsResolver, DNS_RESOLVER_PORT};
 use crate::network::ConnectionType;
 use crate::TrustedPeer;
 
@@ -119,15 +118,6 @@ impl Builder {
     /// If none is provided, a maximum connection time of two hours will be used.
     pub fn maximum_connection_time(mut self, max_connection_time: impl Into<Duration>) -> Self {
         self.config.peer_timeout_config.max_connection_time = max_connection_time.into();
-        self
-    }
-
-    /// Configure the DNS resolver to use when querying DNS seeds.
-    /// Default is `1.1.1.1:53`.
-    pub fn dns_resolver(mut self, resolver: impl Into<IpAddr>) -> Self {
-        let ip_addr = resolver.into();
-        let socket_addr = SocketAddr::new(ip_addr, DNS_RESOLVER_PORT);
-        self.config.dns_resolver = DnsResolver { socket_addr };
         self
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 use crate::{
     chain::ChainState,
-    network::{dns::DnsResolver, ConnectionType, PeerTimeoutConfig},
+    network::{ConnectionType, PeerTimeoutConfig},
     TrustedPeer,
 };
 
@@ -11,7 +11,6 @@ const REQUIRED_PEERS: u8 = 1;
 pub(crate) struct NodeConfig {
     pub required_peers: u8,
     pub white_list: Vec<TrustedPeer>,
-    pub dns_resolver: DnsResolver,
     pub data_path: Option<PathBuf>,
     pub chain_state: Option<ChainState>,
     pub connection_type: ConnectionType,
@@ -23,7 +22,6 @@ impl Default for NodeConfig {
         Self {
             required_peers: REQUIRED_PEERS,
             white_list: Default::default(),
-            dns_resolver: DnsResolver::default(),
             data_path: Default::default(),
             chain_state: Default::default(),
             connection_type: Default::default(),

--- a/src/network/dns.rs
+++ b/src/network/dns.rs
@@ -1,15 +1,6 @@
 extern crate alloc;
-use bitcoin::{
-    key::rand::{thread_rng, RngCore},
-    Network,
-};
-use std::{
-    io::Read,
-    net::{IpAddr, Ipv4Addr, SocketAddr},
-};
-use tokio::net::UdpSocket;
-
-use super::error::DNSQueryError;
+use bitcoin::Network;
+use std::net::IpAddr;
 
 const SIGNET_SEEDS: &[&str; 2] = &["seed.dlsouza.lol", "seed.signet.bitcoin.sprovoost.nl"];
 
@@ -43,48 +34,8 @@ pub(crate) const CBF_V2T_SERVICE_BIT_PREFIX: &str = "x849"; // Compact Filters, 
 const SERVICE_BITS_PREFIX: &[&str; 2] = &[CBF_SERVICE_BIT_PREFIX, CBF_V2T_SERVICE_BIT_PREFIX];
 
 pub(crate) const DNS_RESOLVER_PORT: u16 = 53;
-const LOCAL_HOST: &str = "0.0.0.0:0";
 
-const HEADER_BYTES: usize = 12;
-
-const RECURSIVE_FLAGS: [u8; 2] = [
-    0x01, 0x00, // Default flags with recursive resolver
-];
-
-const QTYPE: [u8; 4] = [
-    0x00, 0x01, // QType: A Record
-    0x00, 0x01, // IN
-];
-
-const COUNTS: [u8; 6] = [
-    0x00, 0x00, // ANCOUNT
-    0x00, 0x00, // NSCOUNT
-    0x00, 0x00, // ARCOUNT
-];
-
-const A_RECORD: u16 = 0x01;
-const A_CLASS: u16 = 0x01;
-const EXPECTED_RDATA_LEN: u16 = 0x04;
-
-#[derive(Debug, Clone, Copy)]
-pub(crate) struct DnsResolver {
-    pub(crate) socket_addr: SocketAddr,
-}
-
-impl Default for DnsResolver {
-    fn default() -> Self {
-        let socket_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(1, 1, 1, 1)), DNS_RESOLVER_PORT);
-        Self { socket_addr }
-    }
-}
-
-impl From<DnsResolver> for SocketAddr {
-    fn from(value: DnsResolver) -> Self {
-        value.socket_addr
-    }
-}
-
-pub(crate) async fn bootstrap_dns(network: Network, dns_resolver: DnsResolver) -> Vec<IpAddr> {
+pub(crate) async fn bootstrap_dns(network: Network) -> Vec<IpAddr> {
     let seeds = match network {
         Network::Bitcoin => MAINNET_SEEDS.to_vec(),
         Network::Testnet => TESTNET_SEEDS.to_vec(),
@@ -94,128 +45,23 @@ pub(crate) async fn bootstrap_dns(network: Network, dns_resolver: DnsResolver) -
     };
     let mut ip_addrs: Vec<IpAddr> = vec![];
     for host in seeds {
-        for filter in SERVICE_BITS_PREFIX {
-            if let Ok(addrs) = DnsQuery::new(host, Some(filter))
-                .lookup(dns_resolver.into())
-                .await
-            {
-                ip_addrs.extend(addrs);
-            }
-        }
-        if let Ok(addrs) = DnsQuery::new(host, None).lookup(dns_resolver.into()).await {
-            ip_addrs.extend(addrs);
-        }
+        let hosts = lookup_hostname(host).await;
+        ip_addrs.extend(hosts);
     }
     ip_addrs
 }
 
-pub(crate) struct DnsQuery {
-    message_id: [u8; 2],
-    message: Vec<u8>,
-    question: Vec<u8>,
-}
-
-impl DnsQuery {
-    pub(crate) fn new(seed: &str, service_bit_prefix: Option<&str>) -> Self {
-        // Build a header
-        let mut rng = thread_rng();
-        let mut message_id = [0, 0];
-        rng.fill_bytes(&mut message_id);
-        let mut message = message_id.to_vec();
-        message.extend(RECURSIVE_FLAGS);
-        message.push(0x00); // QDCOUNT
-        message.push(0x01); // QDCOUNT
-        message.extend(COUNTS);
-        let mut question = encode_qname(seed, service_bit_prefix);
-        question.extend(QTYPE);
-        message.extend_from_slice(&question);
-        Self {
-            message_id,
-            message,
-            question,
+pub(crate) async fn lookup_hostname(host: &str) -> Vec<IpAddr> {
+    let hostnames = [
+        format!("{host}:{DNS_RESOLVER_PORT}"),
+        format!("{}.{host}:{DNS_RESOLVER_PORT}", SERVICE_BITS_PREFIX[0]),
+        format!("{}.{host}:{DNS_RESOLVER_PORT}", SERVICE_BITS_PREFIX[1]),
+    ];
+    let mut ip_addrs = Vec::new();
+    for hostname in hostnames {
+        if let Ok(peers) = tokio::net::lookup_host(hostname).await {
+            ip_addrs.extend(peers.map(|ip| ip.ip()));
         }
     }
-
-    pub(crate) async fn lookup(
-        &self,
-        dns_resolver: SocketAddr,
-    ) -> Result<Vec<IpAddr>, DNSQueryError> {
-        let sock = UdpSocket::bind(LOCAL_HOST).await?;
-        sock.connect(dns_resolver).await?;
-        sock.send(&self.message).await?;
-        let mut response_buf = [0u8; 512];
-        let (amt, _src) = sock.recv_from(&mut response_buf).await?;
-        if amt < HEADER_BYTES {
-            return Err(DNSQueryError::MalformedHeader);
-        }
-        let ips = self.parse_message(&response_buf[..amt])?;
-        Ok(ips)
-    }
-
-    fn parse_message(&self, mut response: &[u8]) -> Result<Vec<IpAddr>, DNSQueryError> {
-        let mut ips = Vec::with_capacity(10);
-        let mut buf: [u8; 2] = [0, 0];
-        response.read_exact(&mut buf)?; // Read 2 bytes
-        if self.message_id != buf {
-            return Err(DNSQueryError::MessageId);
-        }
-        // Read flags and ignore
-        response.read_exact(&mut buf)?; // Read 4 bytes
-        response.read_exact(&mut buf)?; // Read 6 bytes
-        let _qdcount = u16::from_be_bytes(buf);
-        response.read_exact(&mut buf)?; // Read 8 bytes
-        let ancount = u16::from_be_bytes(buf);
-        response.read_exact(&mut buf)?; // Read 10 bytes
-        let _nscount = u16::from_be_bytes(buf);
-        response.read_exact(&mut buf)?; // Read 12 bytes
-        let _arcount = u16::from_be_bytes(buf);
-        // The question should be repeated back to us
-        let mut buf: Vec<u8> = vec![0; self.question.len()];
-        response.read_exact(&mut buf)?;
-        if self.question != buf {
-            return Err(DNSQueryError::Question);
-        }
-        for _ in 0..ancount {
-            let mut buf: [u8; 2] = [0, 0];
-            // Read the compressed NAME field of the record and ignore
-            response.read_exact(&mut buf)?;
-            // Read the TYPE
-            response.read_exact(&mut buf)?;
-            let atype = u16::from_be_bytes(buf);
-            // Read the CLASS
-            response.read_exact(&mut buf)?;
-            let aclass = u16::from_be_bytes(buf);
-            let mut buf: [u8; 4] = [0, 0, 0, 0];
-            // Read the TTL
-            response.read_exact(&mut buf)?;
-            let _ttl = u32::from_be_bytes(buf);
-            let mut buf: [u8; 2] = [0, 0];
-            // Read the RDLENGTH
-            response.read_exact(&mut buf)?;
-            let rdlength = u16::from_be_bytes(buf);
-            // Read RDATA
-            let mut rdata: Vec<u8> = vec![0; rdlength as usize];
-            response.read_exact(&mut rdata)?;
-            if atype == A_RECORD && aclass == A_CLASS && rdlength == EXPECTED_RDATA_LEN {
-                ips.push(IpAddr::V4(Ipv4Addr::new(
-                    rdata[0], rdata[1], rdata[2], rdata[3],
-                )))
-            }
-        }
-        Ok(ips)
-    }
-}
-
-fn encode_qname(domain: &str, filter: Option<&str>) -> Vec<u8> {
-    let mut qname = Vec::new();
-    if let Some(filter) = filter {
-        qname.push(filter.len() as u8);
-        qname.extend(filter.as_bytes());
-    }
-    for label in domain.split('.') {
-        qname.push(label.len() as u8);
-        qname.extend(label.as_bytes());
-    }
-    qname.push(0x00);
-    qname
+    ip_addrs
 }

--- a/src/network/error.rs
+++ b/src/network/error.rs
@@ -163,35 +163,3 @@ impl From<std::io::Error> for Socks5Error {
         Socks5Error::Io(value)
     }
 }
-
-#[derive(Debug)]
-pub(crate) enum DNSQueryError {
-    MessageId,
-    Question,
-    MalformedHeader,
-    Io(io::Error),
-}
-
-impl core::fmt::Display for DNSQueryError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            DNSQueryError::MalformedHeader => write!(f, "the DNS response header was too short."),
-            DNSQueryError::Io(err) => {
-                write!(
-                    f,
-                    "the end of the response was reached before we expected: {err}"
-                )
-            }
-            DNSQueryError::MessageId => write!(f, "mismatch of message ID."),
-            DNSQueryError::Question => write!(f, "the question of the message does not match."),
-        }
-    }
-}
-
-impl_sourceless_error!(DNSQueryError);
-
-impl From<io::Error> for DNSQueryError {
-    fn from(value: io::Error) -> Self {
-        Self::Io(value)
-    }
-}

--- a/src/network/peer_map.rs
+++ b/src/network/peer_map.rs
@@ -25,12 +25,7 @@ use crate::{
     chain::HeightMonitor,
     channel_messages::{CombinedAddr, MainThreadMessage, PeerThreadMessage},
     dialog::Dialog,
-    network::{
-        dns::{bootstrap_dns, DnsResolver},
-        error::PeerError,
-        peer::Peer,
-        PeerId, PeerTimeoutConfig,
-    },
+    network::{dns::bootstrap_dns, error::PeerError, peer::Peer, PeerId, PeerTimeoutConfig},
     prelude::default_port_from_network,
     TrustedPeer,
 };
@@ -65,7 +60,6 @@ pub(crate) struct PeerMap {
     whitelist: Whitelist,
     dialog: Arc<Dialog>,
     timeout_config: PeerTimeoutConfig,
-    dns_resolver: DnsResolver,
 }
 
 impl PeerMap {
@@ -78,7 +72,6 @@ impl PeerMap {
         connection_type: ConnectionType,
         timeout_config: PeerTimeoutConfig,
         height_monitor: Arc<Mutex<HeightMonitor>>,
-        dns_resolver: DnsResolver,
     ) -> Self {
         Self {
             tx_queue: Arc::new(Mutex::new(BroadcastQueue::new())),
@@ -92,7 +85,6 @@ impl PeerMap {
             whitelist,
             dialog,
             timeout_config,
-            dns_resolver,
         }
     }
 
@@ -241,7 +233,7 @@ impl PeerMap {
         let mut db_lock = self.db.lock().await;
         if db_lock.is_empty() {
             crate::debug!("Bootstrapping peers with DNS");
-            let new_peers = bootstrap_dns(self.network, self.dns_resolver)
+            let new_peers = bootstrap_dns(self.network)
                 .await
                 .into_iter()
                 .map(|ip| match ip {

--- a/src/node.rs
+++ b/src/node.rs
@@ -66,7 +66,6 @@ impl Node {
         let NodeConfig {
             required_peers,
             white_list,
-            dns_resolver,
             data_path: _,
             chain_state,
             connection_type,
@@ -93,7 +92,6 @@ impl Node {
             connection_type,
             peer_timeout_config,
             Arc::clone(&height_monitor),
-            dns_resolver,
         );
         // Build the chain
         let chain_state = chain_state.unwrap_or(ChainState::Checkpoint(

--- a/tests/core.rs
+++ b/tests/core.rs
@@ -1,5 +1,5 @@
 use std::{
-    net::{IpAddr, Ipv4Addr, SocketAddrV4},
+    net::{IpAddr, SocketAddrV4},
     path::PathBuf,
     time::Duration,
 };
@@ -7,7 +7,6 @@ use std::{
 use bip157::{
     chain::{checkpoints::HeaderCheckpoint, BlockHeaderChanges, ChainState},
     client::Client,
-    lookup_host,
     node::Node,
     Address, BlockHash, Event, Info, ServiceFlags, Transaction, TrustedPeer, Warning,
 };
@@ -656,8 +655,7 @@ async fn tx_can_broadcast() {
 }
 
 #[tokio::test]
-async fn dns_fn_works() {
-    let cloudflare = IpAddr::V4(Ipv4Addr::new(1, 1, 1, 1));
-    let addrs = lookup_host("seed.bitcoin.sipa.be", cloudflare).await;
-    assert!(!addrs.is_empty());
+async fn dns_works() {
+    let hostname = bip157::lookup_host("seed.bitcoin.sipa.be").await;
+    assert!(!hostname.is_empty());
 }


### PR DESCRIPTION
I just needed enough time to toy around with the `lookup_host` function from `tokio` to figure out how to do domain-based DNS queries. Aparently you just tack on a pointless `53` port. This gets rid of an oddity in the crate.