### PR TITLE
Wait for `getdata` to return from broadcasting a tx

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -26,6 +26,8 @@ impl_sourceless_error!(NodeError);
 pub enum ClientError {
     /// The channel to the node was likely closed and dropped from memory.
     SendError,
+    /// A channel was dropped before sending its value back.
+    RecvError,
 }
 
 impl core::fmt::Display for ClientError {
@@ -33,6 +35,9 @@ impl core::fmt::Display for ClientError {
         match self {
             ClientError::SendError => {
                 write!(f, "the receiver of this message was dropped from memory.")
+            }
+            ClientError::RecvError => {
+                write!(f, "the sender of data was dropped from memory.")
             }
         }
     }
@@ -70,29 +75,3 @@ impl core::fmt::Display for FetchBlockError {
 }
 
 impl_sourceless_error!(FetchBlockError);
-
-/// Errors that occur when fetching the minimum fee rate to broadcast a transaction.
-#[derive(Debug)]
-pub enum FetchFeeRateError {
-    /// The channel to the node was likely closed and dropped from memory.
-    /// This implies the node is not running.
-    SendError,
-    /// The channel to the client was likely closed by the node and dropped from memory.
-    RecvError,
-}
-
-impl core::fmt::Display for FetchFeeRateError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            FetchFeeRateError::SendError => {
-                write!(f, "the receiver of this message was dropped from memory.")
-            }
-            FetchFeeRateError::RecvError => write!(
-                f,
-                "the channel to the client was likely closed by the node and dropped from memory."
-            ),
-        }
-    }
-}
-
-impl_sourceless_error!(FetchFeeRateError);

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -17,12 +17,6 @@ pub enum Info {
     ConnectionsMet,
     /// The progress of the node during the block filter download process.
     Progress(Progress),
-    /// A transaction was sent to a peer. The `wtxid` was advertised to the
-    /// peer, and the peer responded with `getdata`. The transaction was then serialized and sent
-    /// over the wire. This is a strong indication the transaction will propagate, but not
-    /// guaranteed. You may receive duplicate messages for a given `wtxid` given your broadcast
-    /// policy.
-    TxGossiped(Wtxid),
     /// A requested block has been received and is being processed.
     BlockReceived(BlockHash),
 }
@@ -31,7 +25,6 @@ impl core::fmt::Display for Info {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
             Info::SuccessfulHandshake => write!(f, "Successful version handshake with a peer"),
-            Info::TxGossiped(txid) => write!(f, "Transaction gossiped: {txid}"),
             Info::ConnectionsMet => write!(f, "Required connections met"),
             Info::Progress(p) => {
                 let progress_percent = p.percentage_complete();
@@ -130,7 +123,7 @@ pub(crate) enum ClientMessage {
     /// Stop the node.
     Shutdown,
     /// Broadcast a [`crate::Transaction`] with a [`crate::TxBroadcastPolicy`].
-    Broadcast(TxBroadcast),
+    Broadcast(ClientRequest<TxBroadcast, Wtxid>),
     /// Starting at the configured anchor checkpoint, re-emit all filters.
     Rescan,
     /// Explicitly request a block from the node.

--- a/src/network/peer.rs
+++ b/src/network/peer.rs
@@ -263,7 +263,6 @@ impl Peer {
                         self.write_bytes(writer, msg).await?;
                         self.message_state.sent_tx(wtxid);
                         tx_queue.successful(wtxid);
-                        self.dialog.send_info(Info::TxGossiped(wtxid)).await;
                     }
                 }
                 Ok(())

--- a/tests/core.rs
+++ b/tests/core.rs
@@ -619,39 +619,14 @@ async fn tx_can_broadcast() {
     tokio::task::spawn(async move { node.run().await });
     let Client {
         requester,
-        mut info_rx,
-        mut warn_rx,
-        mut event_rx,
+        info_rx: _,
+        warn_rx: _,
+        event_rx: _,
     } = client;
-    requester.broadcast_random(tx).unwrap();
-    tokio::time::timeout(tokio::time::Duration::from_secs(60), async move {
-        loop {
-            tokio::select! {
-                info = info_rx.recv() => {
-                    if let Some(info) = info {
-                        match info {
-                            Info::TxGossiped(_) => { break; },
-                            _ => println!("{info}"),
-                        }
-                    }
-                }
-                event = event_rx.recv() => { drop(event); }
-                warn = warn_rx.recv() => {
-                    if let Some(warn) = warn {
-                        match warn {
-                            Warning::TransactionRejected { payload: _ } => {
-                                panic!("Transaction should be valid");
-                            }
-                            _ => println!("{warn}")
-                        }
-                    }
-
-                }
-            }
-        }
-    })
-    .await
-    .unwrap();
+    tokio::time::timeout(Duration::from_secs(60), requester.broadcast_random(tx))
+        .await
+        .unwrap()
+        .unwrap();
 }
 
 #[tokio::test]


### PR DESCRIPTION
Closes #498 

Instead of sending dissociated `Wtxid` via the `Info` variant, the `oneshot` can be used to send the `Wtxid` back as confirmation that the transaction has gossiped. This makes for much cleaner code on the client side, see the i-test