### PR TITLE
Add fallback trying of both known and new peers

### DIFF
--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -518,11 +518,11 @@ impl AddressBook {
         if self.tried.is_empty() && self.new.is_empty() {
             return None;
         }
-        let use_tried: bool = rand::random();
-        if use_tried && !self.tried.is_empty() {
-            return self.tried.select();
+        if rand::random() {
+            self.tried.select().or_else(|| self.new.select())
+        } else {
+            self.new.select().or_else(|| self.tried.select())
         }
-        self.new.select()
     }
 
     pub(crate) fn failed(&mut self, record: &Record) {


### PR DESCRIPTION
Encountered on regtest. Probably not common for a live network as we hopefully can easily find a new peer.

Previously it was the following:
```
    pub(crate) fn select(&self) -> Option<Record> {
        if self.tried.is_empty() && self.new.is_empty() {
            return None;
        }
        let use_tried: bool = rand::random();
        if use_tried && !self.tried.is_empty() {
            return self.tried.select();
        }
        self.new.select()
    }
```
If `tried.is_empty() = false` and `new.is_empty() = true` we skip the first `if`, then we randomly choose `use_tried = false` then we skip the second `if` down to `self.new.select()` which fails as `new.is_empty() = true`.

Effectively this means if we cannot find a new peer there is a 50% chance we would not use the known ones and fail.

Not sure if we need a distinct test for that.