### PR TITLE
Don't clear filter queue on new block hash

### DIFF
--- a/src/chain/chain.rs
+++ b/src/chain/chain.rs
@@ -198,6 +198,12 @@ impl Chain {
             }
         }
         if request.stop_hash.ne(&batch.stop_hash()) {
+            if self
+                .request_state
+                .was_recently_requested(&batch.stop_hash())
+            {
+                return Ok(CFHeaderChanges::AddedToQueue);
+            }
             return Err(CFHeaderSyncError::UnrequestedStophash);
         }
         // Check that the start height we requested and the length of the batch are aligned.
@@ -291,6 +297,7 @@ impl Chain {
             .header_chain
             .block_hash_at_height(stop_hash_index)
             .unwrap_or(self.header_chain.tip_hash());
+        self.request_state.push_stop_hash(stop_hash);
         self.request_state.last_filter_header_request = Some(FilterHeaderRequest {
             expected_prev_filter_header: prev_header,
             start_height: last_unchecked_cfheader,
@@ -822,7 +829,7 @@ mod tests {
             filter_hashes: stale_hashes,
         };
         let cf_header_sync_res = chain.sync_cf_headers(0.into(), cf_headers);
-        assert!(cf_header_sync_res.is_err());
+        assert!(cf_header_sync_res.is_ok());
         let cf_headers = CFHeaders {
             filter_type: 0x00,
             stop_hash: scenario.last_block_hash(),
@@ -1062,7 +1069,7 @@ mod tests {
             filter_hashes: scenario.n_most_work_filter_hashes(4),
         };
         let cf_header_sync_res = chain.sync_cf_headers(1.into(), cf_headers);
-        assert!(cf_header_sync_res.is_err());
+        assert!(cf_header_sync_res.is_ok());
         chain.next_cf_header_message();
         let cf_headers = CFHeaders {
             filter_type: 0x00,

--- a/src/chain/mod.rs
+++ b/src/chain/mod.rs
@@ -11,7 +11,7 @@ pub mod checkpoints;
 pub(crate) mod error;
 pub(crate) mod graph;
 
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 
 use bitcoin::constants::SUBSIDY_HALVING_INTERVAL;
 use bitcoin::hashes::{sha256d, Hash};
@@ -23,6 +23,8 @@ use bitcoin::{
 
 use crate::network::PeerId;
 use crate::HeaderCheckpoint;
+
+const MAX_PREV_STOP_HASHES: usize = 3;
 
 type Height = u32;
 
@@ -104,6 +106,7 @@ pub(crate) struct FilterRequestState {
     pub last_filter_header_request: Option<FilterHeaderRequest>,
     pub pending_batch: Option<(PeerId, CFHeaderBatch)>,
     pub agreement_state: FilterHeaderAgreements,
+    prev_cf_header_stop_hashes: VecDeque<BlockHash>,
 }
 
 impl FilterRequestState {
@@ -113,7 +116,22 @@ impl FilterRequestState {
             last_filter_header_request: None,
             pending_batch: None,
             agreement_state: FilterHeaderAgreements::new(required),
+            prev_cf_header_stop_hashes: VecDeque::new(),
         }
+    }
+
+    pub(crate) fn push_stop_hash(&mut self, hash: BlockHash) {
+        if self.prev_cf_header_stop_hashes.contains(&hash) {
+            return;
+        }
+        if self.prev_cf_header_stop_hashes.len() >= MAX_PREV_STOP_HASHES {
+            self.prev_cf_header_stop_hashes.pop_front();
+        }
+        self.prev_cf_header_stop_hashes.push_back(hash);
+    }
+
+    pub(crate) fn was_recently_requested(&self, hash: &BlockHash) -> bool {
+        self.prev_cf_header_stop_hashes.contains(hash)
     }
 }
 

--- a/src/node.rs
+++ b/src/node.rs
@@ -618,7 +618,6 @@ impl Node {
                         locator_hashes: self.chain.header_chain.locators(),
                         stop_hash: BlockHash::all_zeros(),
                     };
-                    self.chain.clear_compact_filter_queue();
                     Some(MainThreadMessage::GetHeaders(next_headers))
                 } else {
                     None


### PR DESCRIPTION
Removed clearing of the filter queue on new block hash.
Added a test which captures the previous behaviour of banning a legitimate peer on an "inv" message.

Fixes https://github.com/2140-dev/kyoto/issues/558 (partly? as the state still goes into `Behind` on new "inv" message received)