### PR TITLE
feat: add get_header(height) to Requester API

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -7,6 +7,7 @@ use tokio::sync::mpsc::UnboundedSender;
 use tokio::sync::oneshot;
 
 use crate::chain::block_subsidy;
+use crate::chain::IndexedHeader;
 use crate::messages::ClientRequest;
 use crate::{Event, HeaderCheckpoint, Info, TrustedPeer, Warning};
 
@@ -217,6 +218,21 @@ impl Requester {
         let request = ClientRequest::new((), tx);
         self.ntx
             .send(ClientMessage::BestBlock(request))
+            .map_err(|_| ClientError::SendError)?;
+        rx.await.map_err(|_| ClientError::RecvError)
+    }
+
+    /// Look up a header at a specific height in the locally synced chain of most work.
+    /// Returns `None` if the height is not in the header chain.
+    ///
+    /// # Errors
+    ///
+    /// If the node has stopped running.
+    pub async fn get_header(&self, height: u32) -> Result<Option<IndexedHeader>, ClientError> {
+        let (tx, rx) = tokio::sync::oneshot::channel::<Option<IndexedHeader>>();
+        let request = ClientRequest::new(height, tx);
+        self.ntx
+            .send(ClientMessage::GetHeader(request))
             .map_err(|_| ClientError::SendError)?;
         rx.await.map_err(|_| ClientError::RecvError)
     }

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -7,7 +7,7 @@ use bitcoin::{
     block::Header, p2p::message_network::RejectReason, BlockHash, FeeRate, Transaction, Wtxid,
 };
 
-use crate::chain::BlockHeaderChanges;
+use crate::chain::{BlockHeaderChanges, IndexedHeader};
 use crate::IndexedFilter;
 use crate::{chain::checkpoints::HeaderCheckpoint, IndexedBlock, TrustedPeer};
 
@@ -153,6 +153,8 @@ pub(crate) enum ClientMessage {
     GetBroadcastMinFeeRate(ClientRequest<(), FeeRate>),
     /// Get info on connections
     GetPeerInfo(ClientRequest<(), Vec<(AddrV2, ServiceFlags)>>),
+    /// Look up a header at a specific height in the chain of most work.
+    GetHeader(ClientRequest<u32, Option<IndexedHeader>>),
     /// Send an empty message to see if the node is running.
     NoOp,
 }

--- a/src/node.rs
+++ b/src/node.rs
@@ -29,7 +29,7 @@ use crate::{
         chain::Chain,
         checkpoints::HeaderCheckpoint,
         error::HeaderSyncError,
-        CFHeaderChanges, ChainState, FilterCheck, HeightMonitor,
+        CFHeaderChanges, ChainState, FilterCheck, HeightMonitor, IndexedHeader,
     },
     error::FetchBlockError,
     messages::ClientRequest,
@@ -265,6 +265,17 @@ impl Node {
                                 let peers = self.peer_map.peer_info();
                                 let send_result = oneshot.send(peers);
                                 if send_result.is_err() {
+                                    self.dialog.send_warning(Warning::ChannelDropped);
+                                };
+                            }
+                            ClientMessage::GetHeader(request) => {
+                                let (height, oneshot) = request.into_values();
+                                let header = self
+                                    .chain
+                                    .header_chain
+                                    .header_at_height(height)
+                                    .map(|h| IndexedHeader::new(height, h));
+                                if oneshot.send(header).is_err() {
                                     self.dialog.send_warning(Warning::ChannelDropped);
                                 };
                             }

--- a/tests/core.rs
+++ b/tests/core.rs
@@ -253,6 +253,20 @@ async fn various_client_methods() {
     let peers = requester.peer_info().await.unwrap();
     assert_eq!(peers.len(), 1);
     assert!(requester.is_running());
+    // get_header should return a header within the synced range
+    let header_at_1 = requester.get_header(1).await.unwrap();
+    assert!(header_at_1.is_some());
+    let header_at_1 = header_at_1.unwrap();
+    assert_eq!(header_at_1.height, 1);
+    // get_header at the tip should match the chain tip hash
+    let tip_header = requester.get_header(cp.height).await.unwrap();
+    assert!(tip_header.is_some());
+    let tip_header = tip_header.unwrap();
+    assert_eq!(tip_header.height, cp.height);
+    assert_eq!(tip_header.block_hash(), cp.hash);
+    // get_header beyond the chain should return None
+    let too_high = requester.get_header(cp.height + 1).await.unwrap();
+    assert!(too_high.is_none());
     requester.shutdown().unwrap();
     rpc.stop().unwrap();
 }


### PR DESCRIPTION
## Summary

- Exposes the existing `BlockTree::header_at_height` through the `Requester -> ClientMessage -> Node` channel
- Returns an `Option<IndexedHeader>` for a given block height — zero-cost local `BTreeMap` lookup, no network fetch
- Follows the same `ClientRequest<D, U>` + oneshot pattern used by `chain_tip()`, `peer_info()`, etc.

## Motivation

Consumers that maintain their own view of the chain (e.g., a bridge verifying deposit transactions) need to look up headers at specific heights to cross-check block data received from other sources. Without this, they'd have to maintain a parallel header index or make separate RPC calls to a full node.

## Testing

Extends the existing `various_client_methods` integration test to exercise `get_header`:
- Retrieves a header at a known height (1) and asserts the height matches
- Retrieves the header at the chain tip and asserts the block hash matches `chain_tip().hash`
- Requests a height beyond the chain and asserts `None` is returned

Run with: `just test integration`

## Real-world usage

This feature is actively used in [Hashi](https://www.sui.io/hashi), a decentralized Bitcoin collateralization primitive on [Sui](https://www.sui.io/), built by [Mysten Labs](https://www.mystenlabs.com/). Specifically, `get_header` is used for security-critical verification that bitcoind is not lying about which block contains a deposit transaction — the bridge cross-checks headers at specific heights against its locally synced chain.

See the integration: [MystenLabs/hashi#402](https://github.com/MystenLabs/hashi/pull/402)