### PR TITLE
feat: add height_of_hash to Requester API

### DIFF
--- a/src/chain/graph.rs
+++ b/src/chain/graph.rs
@@ -341,6 +341,14 @@ impl BlockTree {
         self.headers.get(hash).map(|node| node.header)
     }
 
+    // Returns the height of `hash` only when it sits on the canonical chain of most work.
+    // Returns `None` for unknown hashes and for hashes on stale/reorganized branches.
+    pub(crate) fn height_of_hash_canonical_only(&self, hash: BlockHash) -> Option<Height> {
+        let height = self.headers.get(&hash).map(|node| node.height)?;
+        let canonical = self.block_hash_at_height(height)?;
+        (canonical == hash).then_some(height)
+    }
+
     pub(crate) fn height_of_hash(&self, hash: BlockHash) -> Option<Height> {
         self.headers.get(&hash).map(|node| node.height)
     }
@@ -614,6 +622,20 @@ mod tests {
         assert_eq!(chain.header_at_height(10), Some(new_block_10));
         assert_eq!(chain.header_at_height(9), Some(base[1].0));
         assert_eq!(chain.header_at_height(8), Some(base[0].0));
+        // height_of_hash returns the height for hashes on the canonical chain
+        assert_eq!(chain.height_of_hash(new_block_10.block_hash()), Some(10));
+        assert_eq!(chain.height_of_hash(block_11.block_hash()), Some(11));
+        // ...and None for hashes that were reorganized away, even though the header
+        // is still stored in the graph.
+        assert_eq!(
+            chain.height_of_hash_canonical_only(old_block_10.block_hash()),
+            None
+        );
+        // Unknown hashes also return None.
+        let unknown =
+            BlockHash::from_str("0000000000000000000000000000000000000000000000000000000000000000")
+                .unwrap();
+        assert_eq!(chain.height_of_hash(unknown), None);
     }
 
     #[test]

--- a/src/client.rs
+++ b/src/client.rs
@@ -237,6 +237,21 @@ impl Requester {
         rx.await.map_err(|_| ClientError::RecvError)
     }
 
+    /// Look up the height of a block hash in the locally synced chain of most work.
+    /// Returns `None` if the hash is not in the chain of most work.
+    ///
+    /// # Errors
+    ///
+    /// If the node has stopped running.
+    pub async fn height_of_hash(&self, hash: BlockHash) -> Result<Option<u32>, ClientError> {
+        let (tx, rx) = tokio::sync::oneshot::channel::<Option<u32>>();
+        let request = ClientRequest::new(hash, tx);
+        self.ntx
+            .send(ClientMessage::HeightOfHash(request))
+            .map_err(|_| ClientError::SendError)?;
+        rx.await.map_err(|_| ClientError::RecvError)
+    }
+
     /// Check if the node is running.
     pub fn is_running(&self) -> bool {
         self.ntx.send(ClientMessage::NoOp).is_ok()

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -155,6 +155,8 @@ pub(crate) enum ClientMessage {
     GetPeerInfo(ClientRequest<(), Vec<(AddrV2, ServiceFlags)>>),
     /// Look up a header at a specific height in the chain of most work.
     GetHeader(ClientRequest<u32, Option<IndexedHeader>>),
+    /// Look up the height of a block hash in the chain of most work.
+    HeightOfHash(ClientRequest<BlockHash, Option<u32>>),
     /// Send an empty message to see if the node is running.
     NoOp,
 }

--- a/src/node.rs
+++ b/src/node.rs
@@ -264,6 +264,14 @@ impl Node {
                                     self.dialog.send_warning(Warning::ChannelDropped);
                                 };
                             }
+                            ClientMessage::HeightOfHash(request) => {
+                                let (hash, oneshot) = request.into_values();
+                                let height =
+                                    self.chain.header_chain.height_of_hash_canonical_only(hash);
+                                if oneshot.send(height).is_err() {
+                                    self.dialog.send_warning(Warning::ChannelDropped);
+                                };
+                            }
                             ClientMessage::NoOp => (),
                         }
                     }

--- a/tests/core.rs
+++ b/tests/core.rs
@@ -267,6 +267,14 @@ async fn various_client_methods() {
     // get_header beyond the chain should return None
     let too_high = requester.get_header(cp.height + 1).await.unwrap();
     assert!(too_high.is_none());
+    // height_of_hash for the chain tip should return the tip height
+    let tip_height = requester.height_of_hash(cp.hash).await.unwrap();
+    assert!(tip_height.is_some());
+    assert_eq!(tip_height.unwrap(), cp.height);
+    // height_of_hash for an unknown hash should return None
+    let fake_hash: BlockHash = bitcoin::hashes::Hash::all_zeros();
+    let unknown = requester.height_of_hash(fake_hash).await.unwrap();
+    assert!(unknown.is_none());
     requester.shutdown().unwrap();
     rpc.stop().unwrap();
 }


### PR DESCRIPTION
## Summary

- Exposes `BlockTree::height_of_hash` through the `Requester -> ClientMessage -> Node` channel
- Given a `BlockHash`, returns `Option<u32>` — the height of that block in the chain of most work, or `None` if the hash is unknown
- Zero-cost local `HashMap` lookup, no network fetch

## Motivation

Consumers that receive block hashes from external sources (e.g., a bridge watching for deposit confirmations) need to verify chain membership and determine block height without making separate RPC calls to a full node. This complements the existing `chain_tip()` API by allowing hash-to-height lookups against the locally synced header chain.

## Testing

Extends the existing `various_client_methods` integration test to exercise `height_of_hash`:
- Looks up the chain tip hash and asserts the returned height matches `chain_tip().height`
- Looks up an all-zeros hash and asserts `None` is returned

Run with: `just test integration`

## Real-world usage

This feature is actively used in [Hashi](https://www.sui.io/hashi), a decentralized Bitcoin collateralization primitive on [Sui](https://www.sui.io/), built by [Mysten Labs](https://www.mystenlabs.com/). `height_of_hash` is used to verify block chain membership — given a block hash from bitcoind, Hashi can confirm it exists in the locally synced chain of most work without needing a separate RPC call.

See the integration: [MystenLabs/hashi#402](https://github.com/MystenLabs/hashi/pull/402)