### PR TITLE
feat: add DNS resolution to TrustedPeer

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -185,6 +185,18 @@ impl std::cmp::Ord for IndexedFilter {
     }
 }
 
+#[derive(Debug, Clone)]
+enum TrustedPeerInner {
+    Addr(AddrV2),
+    Hostname(String),
+}
+
+impl From<AddrV2> for TrustedPeerInner {
+    fn from(addr: AddrV2) -> Self {
+        Self::Addr(addr)
+    }
+}
+
 /// A peer on the Bitcoin P2P network
 ///
 /// # Building peers
@@ -205,22 +217,25 @@ impl std::cmp::Ord for IndexedFilter {
 /// // Or implicitly with `into`
 /// let local_host = IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0));
 /// let trusted: TrustedPeer = (local_host, None).into();
+///
+/// // Or from a hostname — resolution happens at connection time.
+/// let trusted = TrustedPeer::from_hostname("bitcoind.svc.local", 8333);
 /// ```
 #[derive(Debug, Clone)]
 pub struct TrustedPeer {
-    /// The IP address of the remote node to connect to.
-    pub address: AddrV2,
-    /// The port to establish a TCP connection. If none is provided, the typical Bitcoin Core port is used as the default.
-    pub port: Option<u16>,
-    /// The services this peer is known to offer before starting the node.
-    pub known_services: ServiceFlags,
+    // The address or hostname of the remote node to connect to.
+    address: TrustedPeerInner,
+    // The port to establish a TCP connection. If none is provided, the typical Bitcoin Core port is used as the default.
+    port: Option<u16>,
+    // The services this peer is known to offer before starting the node.
+    known_services: ServiceFlags,
 }
 
 impl TrustedPeer {
     /// Create a new trusted peer.
-    pub fn new(address: AddrV2, port: Option<u16>, services: ServiceFlags) -> Self {
+    pub fn new(address: impl Into<AddrV2>, port: Option<u16>, services: ServiceFlags) -> Self {
         Self {
-            address,
+            address: TrustedPeerInner::Addr(address.into()),
             port,
             known_services: services,
         }
@@ -233,7 +248,7 @@ impl TrustedPeer {
             IpAddr::V6(ip) => AddrV2::Ipv6(ip),
         };
         Self {
-            address,
+            address: TrustedPeerInner::Addr(address),
             port: None,
             known_services: ServiceFlags::NONE,
         }
@@ -247,15 +262,24 @@ impl TrustedPeer {
             SocketAddr::V6(ip) => AddrV2::Ipv6(*ip.ip()),
         };
         Self {
-            address,
+            address: TrustedPeerInner::Addr(address),
             port: Some(socket_addr.port()),
             known_services: ServiceFlags::NONE,
         }
     }
 
-    /// The IP address of the trusted peer.
-    pub fn address(&self) -> AddrV2 {
-        self.address.clone()
+    /// Create a new trusted peer from a DNS hostname.
+    ///
+    /// The hostname is stored as-is and resolved to an IP address at the
+    /// time a connection is attempted, via [`tokio::net::lookup_host`]. If
+    /// resolution fails or yields no addresses, the peer is skipped and
+    /// the next configured peer is tried.
+    pub fn from_hostname(hostname: impl Into<String>, port: u16) -> Self {
+        Self {
+            address: TrustedPeerInner::Hostname(hostname.into()),
+            port: Some(port),
+            known_services: ServiceFlags::NONE,
+        }
     }
 
     /// A recommended port to connect to, if there is one.
@@ -281,12 +305,6 @@ impl From<(IpAddr, Option<u16>)> for TrustedPeer {
             IpAddr::V6(ip) => AddrV2::Ipv6(ip),
         };
         TrustedPeer::new(address, value.1, ServiceFlags::NONE)
-    }
-}
-
-impl From<TrustedPeer> for (AddrV2, Option<u16>) {
-    fn from(value: TrustedPeer) -> Self {
-        (value.address(), value.port())
     }
 }
 

--- a/src/network/peer_map.rs
+++ b/src/network/peer_map.rs
@@ -24,7 +24,7 @@ use crate::{
     broadcaster::BroadcastQueue,
     default_port_from_network,
     network::{dns::bootstrap_dns, error::PeerError, peer::Peer, PeerId, PeerTimeoutConfig},
-    BlockType, Dialog, TrustedPeer,
+    BlockType, Dialog, TrustedPeer, TrustedPeerInner,
 };
 
 use super::{AddressBook, ConnectionType, MainThreadMessage, PeerThreadMessage};
@@ -217,13 +217,53 @@ impl PeerMap {
     // as long as it is not from the same netgroup. If there are no peers in the database, try DNS.
     // When `whitelist_only` is set, only whitelist peers are used.
     pub async fn next_peer(&mut self) -> Option<Record> {
-        if let Some(peer) = self.whitelist.pop() {
-            crate::debug!("Using a configured peer");
+        while let Some(peer) = self.whitelist.pop() {
             let port = peer
                 .port
                 .unwrap_or(default_port_from_network(&self.network));
-            let record = Record::new(peer.address(), port, peer.known_services, &LOCAL_HOST);
-            return Some(record);
+            let addr = match peer.address {
+                TrustedPeerInner::Addr(addr) => addr,
+                TrustedPeerInner::Hostname(host) => {
+                    crate::debug!(format!("Resolving hostname {host}:{port}"));
+                    match tokio::net::lookup_host((host.as_str(), port)).await {
+                        Ok(iter) => {
+                            let resolved: Vec<AddrV2> = iter
+                                .map(|sa| match sa.ip() {
+                                    IpAddr::V4(ip) => AddrV2::Ipv4(ip),
+                                    IpAddr::V6(ip) => AddrV2::Ipv6(ip),
+                                })
+                                .collect();
+                            if resolved.is_empty() {
+                                crate::debug!(format!(
+                                    "Hostname {host} resolved to no addresses, skipping"
+                                ));
+                                continue;
+                            }
+                            crate::debug!(format!(
+                                "Resolved {host} to {} address(es)",
+                                resolved.len()
+                            ));
+                            // Push every resolved address onto the whitelist so each is tried on
+                            // a subsequent call. Reversed so the resolver's preferred order is
+                            // preserved under LIFO pop.
+                            for resolved_addr in resolved.into_iter().rev() {
+                                self.whitelist.push(TrustedPeer {
+                                    address: TrustedPeerInner::Addr(resolved_addr),
+                                    port: Some(port),
+                                    known_services: peer.known_services,
+                                });
+                            }
+                            continue;
+                        }
+                        Err(_) => {
+                            crate::debug!(format!("Failed to resolve hostname {host}"));
+                            continue;
+                        }
+                    }
+                }
+            };
+            crate::debug!("Using a configured peer");
+            return Some(Record::new(addr, port, peer.known_services, &LOCAL_HOST));
         }
         if self.whitelist_only {
             return None;

--- a/tests/core.rs
+++ b/tests/core.rs
@@ -685,6 +685,7 @@ async fn whitelist_only_sync() {
     assert_eq!(cp.hash, best);
     requester.shutdown().unwrap();
     rpc.stop().unwrap();
+    // No peer available, white list only.
     let builder = bip157::builder::Builder::new(bitcoin::Network::Regtest)
         .chain_state(ChainState::Checkpoint(HeaderCheckpoint::from_genesis(
             bitcoin::Network::Regtest,
@@ -694,6 +695,34 @@ async fn whitelist_only_sync() {
     let (node, _client) = builder.build();
     let result = node.run().await;
     assert!(result.is_err());
+    // Peer resolved from hostname.
+    let (bitcoind, socket_addr) = start_bitcoind(true).unwrap();
+    let rpc = &bitcoind.client;
+    let miner = rpc.new_address().unwrap();
+    mine_blocks(rpc, &miner, 10, 2).await;
+    let best = best_hash(rpc);
+    let peer = TrustedPeer::from_hostname(socket_addr.ip().to_string(), socket_addr.port());
+    let builder = bip157::builder::Builder::new(bitcoin::Network::Regtest)
+        .chain_state(ChainState::Checkpoint(HeaderCheckpoint::from_genesis(
+            bitcoin::Network::Regtest,
+        )))
+        .add_peer(peer)
+        .whitelist_only()
+        .data_dir(&tempdir);
+    let (node, client) = builder.build();
+    tokio::task::spawn(async move { node.run().await });
+    let Client {
+        requester,
+        info_rx,
+        warn_rx,
+        event_rx: mut channel,
+    } = client;
+    tokio::task::spawn(async move { print_logs(info_rx, warn_rx).await });
+    sync_assert(&best, &mut channel).await;
+    let cp = requester.chain_tip().await.unwrap();
+    assert_eq!(cp.hash, best);
+    requester.shutdown().unwrap();
+    rpc.stop().unwrap();
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

Extends `TrustedPeer` so a peer can be given as a DNS hostname instead of a pre-resolved `AddrV2`. Hostnames are resolved at connection time in `PeerMap::next_peer` via `tokio::net::lookup_host`, so the backing IP can change between reconnections without the caller pre-resolving.

Replaces the earlier `DnsPeer` + round-robin approach from this PR. The reworked design keeps kyoto free of any client-specific retry policy, matching the reviewer's ask — see [this comment](https://github.com/2140-dev/kyoto/pull/566#issuecomment-3416046080).

## API shape

```rust
#[derive(Debug, Clone)]
pub enum PeerAddress {
    /// A pre-resolved Bitcoin P2P address.
    Addr(AddrV2),
    /// A DNS hostname, resolved at connection time.
    Hostname(String),
}

impl From<AddrV2> for PeerAddress { ... }

#[derive(Debug, Clone)]
pub struct TrustedPeer {
    pub address: PeerAddress,   // was: AddrV2
    pub port: Option<u16>,
    pub known_services: ServiceFlags,
}

impl TrustedPeer {
    pub fn from_hostname(hostname: impl Into<String>, port: u16) -> Self { ... }
    // existing constructors (`new`, `from_ip`, `from_socket_addr`) keep working
}
```

- `TrustedPeer::new(AddrV2::Ipv4(...), ..)` and every `Into<TrustedPeer>` impl keep compiling because `PeerAddress: From<AddrV2>` and `new` takes `impl Into<PeerAddress>`.
- New constructor `TrustedPeer::from_hostname(host, port)` for the hostname path.

## Semantics

- **Resolution at connect time.** Every call to `next_peer` that pops a `PeerAddress::Hostname` entry does a fresh `lookup_host`. No caching inside kyoto.
- **Consumed on use.** Same as the existing IP-based `TrustedPeer` — popped from the whitelist, never reinstated. Retries and re-resolution across node lifetimes are the client's responsibility (rebuild the node on `NoReachablePeers`).
- **Resolution failure is non-fatal.** If a hostname fails to resolve (or returns no addresses), the entry is logged and the next whitelist entry is tried. `NoReachablePeers` is only surfaced once the whole whitelist is exhausted.
- **First address wins.** If the hostname resolves to multiple addresses, the first returned by the resolver is used — good enough for single-pod K8s Service / ECS targets; multi-address fallback is future work.
- **Socks5 / Tor.** Hostnames are resolved locally even when a Socks5 proxy is configured. Onion addresses remain routed via `AddrV2::TorV3 → SocksConnection::OnionService` as today. Resolving hostnames inside the proxy (via the Socks5 `0x03` domain-name address type) is out of scope for this PR.

## Breaking changes

Minimal, all on the `TrustedPeer` surface:

- `pub address: AddrV2` → `pub address: PeerAddress`. Direct struct-literal construction needs `.into()` (e.g. `TrustedPeer { address: AddrV2::Ipv4(ip).into(), ... }`). Callers using any constructor or `Into` impl are unaffected.
- `fn address(&self) -> AddrV2` → `fn address(&self) -> &PeerAddress`.
- `impl From<TrustedPeer> for (AddrV2, Option<u16>)` → `impl From<TrustedPeer> for (PeerAddress, Option<u16>)`.

## Testing

New `trusted_peer_hostname_sync` integration test:
- Starts a regtest bitcoind and mines 10 blocks.
- Builds a `TrustedPeer::from_hostname(socket_addr.ip().to_string(), socket_addr.port())` — an IP literal used as the hostname so the test is deterministic on CI (on macOS, `localhost` resolves to `::1` but bitcoind only listens on IPv4).
- Syncs and asserts the tip hash matches. Debug log confirms the `tokio::net::lookup_host` path fires.

Real-hostname resolution (through the OS resolver) is still covered by the existing `dns_works` test.

Full integration suite passes locally (`just test integration`, 10/10 green, ~106s).

## Motivation

In containerized / cloud-native environments, Bitcoin peers often sit behind service hostnames whose backing IPs rotate (Kubernetes Services, ECS service discovery, Consul, etc.). `TrustedPeer` today requires a resolved `SocketAddr` at build time; hostname support lets users defer resolution to connection time.

Used in [Hashi](https://www.sui.io/hashi) — a decentralized Bitcoin collateralization primitive on [Sui](https://www.sui.io/), built by [Mysten Labs](https://www.mystenlabs.com/). Hashi's bitcoind sits behind a Kubernetes service DNS name whose backing pod IP rotates on restart; hashi runs a supervisor that rebuilds the kyoto node on `NoReachablePeers`, which matches the "consumed on use, rebuild to retry" model this PR settles on. See [MystenLabs/hashi#402](https://github.com/MystenLabs/hashi/pull/402).