### PR TITLE
Use BIP-130 `sendheaders`

### DIFF
--- a/src/chain/chain.rs
+++ b/src/chain/chain.rs
@@ -6,14 +6,12 @@ use bitcoin::{
     p2p::message_filter::{CFHeaders, CFilter, GetCFHeaders, GetCFilters},
     BlockHash, Network,
 };
-use tokio::sync::Mutex;
 
 use super::{
     error::{CFHeaderSyncError, CFilterSyncError, HeaderSyncError},
     graph::{AcceptHeaderChanges, BlockTree, HeaderRejection},
     CFHeaderBatch, CFHeaderChanges, ChainState, Filter, FilterCheck, FilterHeaderRequest,
-    FilterRequest, FilterRequestState, HeaderSyncEffect, HeaderValidationExt, HeightMonitor,
-    PeerId,
+    FilterRequest, FilterRequestState, HeaderSyncEffect, HeaderValidationExt, PeerId,
 };
 use crate::{chain::BlockHeaderChanges, messages::Event, Dialog, Info, Progress};
 use crate::{FilterType, IndexedFilter};
@@ -26,7 +24,6 @@ pub(crate) struct Chain {
     pub(crate) header_chain: BlockTree,
     request_state: FilterRequestState,
     network: Network,
-    heights: Arc<Mutex<HeightMonitor>>,
     dialog: Arc<Dialog>,
     filter_type: FilterType,
 }
@@ -36,7 +33,6 @@ impl Chain {
         network: Network,
         chain_state: ChainState,
         dialog: Arc<Dialog>,
-        height_monitor: Arc<Mutex<HeightMonitor>>,
         quorum_required: u8,
         filter_type: FilterType,
     ) -> Self {
@@ -60,7 +56,6 @@ impl Chain {
             header_chain,
             request_state: FilterRequestState::new(quorum_required),
             network,
-            heights: height_monitor,
             dialog,
             filter_type,
         }
@@ -73,17 +68,6 @@ impl Chain {
             .take(10)
             .map(|index| (index.height, index.header))
             .collect()
-    }
-
-    // Do we have best known height and is our height equal to it
-    // If our height is greater, we received partial inventory, and
-    // the header message contained the rest of the new blocks.
-    pub(crate) async fn is_synced(&self) -> bool {
-        let height_lock = self.heights.lock().await;
-        match height_lock.max() {
-            Some(peer_max) => self.header_chain.height() >= peer_max,
-            None => false,
-        }
     }
 
     // Sync the chain with headers from a peer, adjusting to reorgs if needed
@@ -418,13 +402,8 @@ impl Chain {
             )))
             .await;
         crate::debug!(format!(
-            "Headers: ({}/{}) CFHeaders: ({}/{}) CFilters: ({}/{})",
+            "Headers: {} CFHeaders: ({}/{}) CFilters: ({}/{})",
             self.header_chain.height(),
-            self.heights
-                .lock()
-                .await
-                .max()
-                .unwrap_or(self.header_chain.height()),
             self.header_chain.total_filter_headers_synced(),
             self.header_chain.internal_chain_len() as u32,
             self.header_chain.total_filters_synced(),
@@ -447,7 +426,6 @@ mod tests {
         BlockHash, FilterHash, FilterHeader,
     };
     use corepc_node::serde_json;
-    use tokio::sync::Mutex;
 
     use crate::chain::ChainState;
     use crate::FilterType;
@@ -457,13 +435,9 @@ mod tests {
         Dialog,
     };
 
-    use super::{CFHeaderChanges, Chain, HeightMonitor};
+    use super::{CFHeaderChanges, Chain};
 
-    fn new_regtest(
-        anchor: HeaderCheckpoint,
-        height_monitor: Arc<Mutex<HeightMonitor>>,
-        peers: u8,
-    ) -> Chain {
+    fn new_regtest(anchor: HeaderCheckpoint, peers: u8) -> Chain {
         let (info_tx, _) = tokio::sync::mpsc::channel::<Info>(1);
         let (warn_tx, _) = tokio::sync::mpsc::unbounded_channel::<Warning>();
         let (event_tx, _) = tokio::sync::mpsc::unbounded_channel::<Event>();
@@ -471,7 +445,6 @@ mod tests {
             bitcoin::Network::Regtest,
             ChainState::Checkpoint(anchor),
             Arc::new(Dialog::new(info_tx, warn_tx, event_tx)),
-            height_monitor,
             peers,
             FilterType::Basic,
         )
@@ -583,8 +556,7 @@ mod tests {
     #[tokio::test]
     async fn test_fork_includes_old_vals() {
         let gen = base_block();
-        let height_monitor = Arc::new(Mutex::new(HeightMonitor::new()));
-        let mut chain = new_regtest(gen, height_monitor, 1);
+        let mut chain = new_regtest(gen, 1);
         let chain_scenario = load_scenario();
         let canonical = chain_scenario.most_work;
         let mut canonical_iter = canonical.into_iter();
@@ -622,16 +594,13 @@ mod tests {
     #[tokio::test]
     async fn test_filters_out_of_order() {
         let gen = base_block();
-        let height_monitor = Arc::new(Mutex::new(HeightMonitor::new()));
-        let mut chain = new_regtest(gen, height_monitor.clone(), 1);
+        let mut chain = new_regtest(gen, 1);
         let scenario = load_scenario();
         let header_batch = scenario.most_work_headers();
         let block_5 = scenario.last_block_header();
         let chain_sync = chain.sync_chain(header_batch);
         assert!(chain_sync.is_ok());
         assert_eq!(chain.header_chain.height(), 2501);
-        height_monitor.lock().await.insert(1.into(), 2501);
-        assert!(chain.is_synced().await);
         let filter_hashes = scenario.n_most_work_filter_hashes(5);
         chain.next_cf_header_message();
         let cf_headers = CFHeaders {
@@ -655,15 +624,12 @@ mod tests {
     #[tokio::test]
     async fn test_bad_filter() {
         let gen = base_block();
-        let height_monitor = Arc::new(Mutex::new(HeightMonitor::new()));
-        let mut chain = new_regtest(gen, height_monitor.clone(), 1);
+        let mut chain = new_regtest(gen, 1);
         let scenario = load_scenario();
         let header_batch = scenario.most_work_headers();
         let chain_sync = chain.sync_chain(header_batch);
         assert!(chain_sync.is_ok());
         assert_eq!(chain.header_chain.height(), 2501);
-        height_monitor.lock().await.insert(1.into(), 2501);
-        assert!(chain.is_synced().await);
         chain.next_cf_header_message();
         let cf_headers = CFHeaders {
             filter_type: 0x00,
@@ -692,15 +658,12 @@ mod tests {
     #[tokio::test]
     async fn test_has_conflict() {
         let gen = base_block();
-        let height_monitor = Arc::new(Mutex::new(HeightMonitor::new()));
-        let mut chain = new_regtest(gen, height_monitor.clone(), 2);
+        let mut chain = new_regtest(gen, 2);
         let scenario = load_scenario();
         let header_batch = scenario.most_work_headers();
         let chain_sync = chain.sync_chain(header_batch);
         assert!(chain_sync.is_ok());
         assert_eq!(chain.header_chain.height(), 2501);
-        height_monitor.lock().await.insert(1.into(), 2501);
-        assert!(chain.is_synced().await);
         chain.next_cf_header_message();
         let cf_headers = CFHeaders {
             filter_type: 0x00,
@@ -754,15 +717,12 @@ mod tests {
     #[tokio::test]
     async fn test_uneven_cf_headers() {
         let gen = base_block();
-        let height_monitor = Arc::new(Mutex::new(HeightMonitor::new()));
-        let mut chain = new_regtest(gen, height_monitor.clone(), 2);
+        let mut chain = new_regtest(gen, 2);
         let scenario = load_scenario();
         let header_batch = scenario.most_work_headers();
         let chain_sync = chain.sync_chain(header_batch);
         assert!(chain_sync.is_ok());
         assert_eq!(chain.header_chain.height(), 2501);
-        height_monitor.lock().await.insert(1.into(), 2501);
-        assert!(chain.is_synced().await);
         chain.next_cf_header_message();
         let cf_headers = CFHeaders {
             filter_type: 0x00,
@@ -805,8 +765,7 @@ mod tests {
     #[tokio::test]
     async fn test_reorg_no_queue() {
         let gen = base_block();
-        let height_monitor = Arc::new(Mutex::new(HeightMonitor::new()));
-        let mut chain = new_regtest(gen, height_monitor.clone(), 2);
+        let mut chain = new_regtest(gen, 2);
         let scenario = load_scenario();
         let mut stale_headers = scenario.n_most_work_headers(3);
         let stale_block_data = scenario.stale_chain.first().unwrap();
@@ -814,8 +773,6 @@ mod tests {
         let chain_sync = chain.sync_chain(stale_headers);
         assert!(chain_sync.is_ok());
         assert_eq!(chain.header_chain.height(), 2500);
-        height_monitor.lock().await.insert(1.into(), 2500);
-        assert!(chain.is_synced().await);
         chain.next_cf_header_message();
         // Reorganize the blocks
         let most_work = scenario.most_work_headers();
@@ -865,8 +822,7 @@ mod tests {
     #[tokio::test]
     async fn test_reorg_with_queue() {
         let gen = base_block();
-        let height_monitor = Arc::new(Mutex::new(HeightMonitor::new()));
-        let mut chain = new_regtest(gen, height_monitor.clone(), 2);
+        let mut chain = new_regtest(gen, 2);
         let scenario = load_scenario();
         let mut header_batch = scenario.n_most_work_headers(3);
         let stale = scenario
@@ -878,8 +834,6 @@ mod tests {
         let chain_sync = chain.sync_chain(header_batch);
         assert!(chain_sync.is_ok());
         assert_eq!(chain.header_chain.height(), 2500);
-        height_monitor.lock().await.insert(1.into(), 2500);
-        assert!(chain.is_synced().await);
         chain.next_cf_header_message();
         let mut stale_hashes = scenario.n_most_work_filter_hashes(3);
         let stale_hash = scenario
@@ -930,8 +884,7 @@ mod tests {
     #[ignore = "temporarily broken due to hex decoding"]
     async fn reorg_during_filter_sync() {
         let gen = base_block();
-        let height_monitor = Arc::new(Mutex::new(HeightMonitor::new()));
-        let mut chain = new_regtest(gen, height_monitor.clone(), 2);
+        let mut chain = new_regtest(gen, 2);
         let block_1: Header = deserialize(&hex::decode("000000206a7cb0df73f2a05fd8eb63de4c9c0fda70d8848f3581b601338b530088474f4bbe54a272e64276a49cf98359a6e43563b6527cce7c9434c0c2ca21b4710b84593362c266ffff7f2000000000").unwrap()).unwrap();
         let block_2: Header = deserialize(&hex::decode("000000204326468f18d82108c98e5a328192770c8cb8d4e3322a4df708fe3232b3f0797dcd9468dd32ad9d68cfd49048378ec2caae965e4998200e4f83cba92f396f0b373462c266ffff7f2001000000").unwrap()).unwrap();
         let block_3: Header = deserialize(&hex::decode("00000020a860ab5e9320ad1e0318e154ea31cab1e030a1f4e1bcf89c63bfdf3055852d01053e4b600cfa947ce54315cc62b23e706dbfca5566f3156b272bf1f8971d930b3462c266ffff7f2001000000").unwrap()).unwrap();
@@ -942,8 +895,6 @@ mod tests {
         let chain_sync = chain.sync_chain(header_batch);
         assert!(chain_sync.is_ok());
         assert_eq!(chain.header_chain.height(), 2500);
-        height_monitor.lock().await.insert(1.into(), 2500);
-        assert!(chain.is_synced().await);
         let filter_1 = hex::decode("018976c0").unwrap();
         let filter_2 = hex::decode("018b1f28").unwrap();
         let filter_3 = hex::decode("01117310").unwrap();
@@ -999,8 +950,6 @@ mod tests {
         let header_batch = vec![new_block_4, block_5];
         let chain_sync = chain.sync_chain(header_batch);
         assert!(chain_sync.is_ok());
-        height_monitor.lock().await.increment(1.into());
-        assert!(chain.is_synced().await);
         // Request the headers again
         chain.next_cf_header_message();
         let cf_headers = CFHeaders {
@@ -1046,8 +995,7 @@ mod tests {
     #[tokio::test]
     async fn test_inv_no_queue() {
         let gen = base_block();
-        let height_monitor = Arc::new(Mutex::new(HeightMonitor::new()));
-        let mut chain = new_regtest(gen, height_monitor.clone(), 2);
+        let mut chain = new_regtest(gen, 2);
         let scenario = load_scenario();
         let header_batch = scenario.n_most_work_headers(4);
         let block_4 = header_batch
@@ -1057,14 +1005,11 @@ mod tests {
         let chain_sync = chain.sync_chain(header_batch);
         assert!(chain_sync.is_ok());
         assert_eq!(chain.header_chain.height(), 2500);
-        height_monitor.lock().await.insert(1.into(), 2500);
-        assert!(chain.is_synced().await);
         chain.next_cf_header_message();
         let block_5 = scenario.last_block_header();
         let chain_sync = chain.sync_chain(vec![block_5]);
         assert!(chain_sync.is_ok());
         assert_eq!(chain.header_chain.height(), 2501);
-        assert!(chain.is_synced().await);
         chain.next_cf_header_message();
         let cf_headers = CFHeaders {
             filter_type: 0x00,
@@ -1096,16 +1041,13 @@ mod tests {
     #[tokio::test]
     async fn test_inv_with_queue() {
         let gen = base_block();
-        let height_monitor = Arc::new(Mutex::new(HeightMonitor::new()));
-        let mut chain = new_regtest(gen, height_monitor.clone(), 2);
+        let mut chain = new_regtest(gen, 2);
         let scenario = load_scenario();
         let first_four = scenario.n_most_work_headers(4);
         let block_4 = first_four.last().copied().unwrap();
         let chain_sync = chain.sync_chain(first_four);
         assert!(chain_sync.is_ok());
         assert_eq!(chain.header_chain.height(), 2500);
-        height_monitor.lock().await.insert(1.into(), 2500);
-        assert!(chain.is_synced().await);
         let first_four_filter_hashes = scenario.n_most_work_filter_hashes(4);
         chain.next_cf_header_message();
         let cf_headers = CFHeaders {

--- a/src/chain/mod.rs
+++ b/src/chain/mod.rs
@@ -11,7 +11,7 @@ pub mod checkpoints;
 pub(crate) mod error;
 pub(crate) mod graph;
 
-use std::collections::{HashMap, VecDeque};
+use std::collections::VecDeque;
 
 use bitcoin::constants::SUBSIDY_HALVING_INTERVAL;
 use bitcoin::hashes::{sha256d, Hash};
@@ -25,8 +25,6 @@ use crate::network::PeerId;
 use crate::HeaderCheckpoint;
 
 const MAX_PREV_STOP_HASHES: usize = 3;
-
-type Height = u32;
 
 /// A block header with associated height.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -290,37 +288,6 @@ impl Filter {
     }
 }
 
-#[derive(Debug)]
-pub(crate) struct HeightMonitor {
-    map: HashMap<PeerId, Height>,
-}
-
-impl HeightMonitor {
-    pub(crate) fn new() -> Self {
-        Self {
-            map: HashMap::new(),
-        }
-    }
-
-    pub(crate) fn max(&self) -> Option<Height> {
-        self.map.values().copied().max()
-    }
-
-    pub(crate) fn retain(&mut self, peers: &[PeerId]) {
-        self.map.retain(|peer_id, _| peers.contains(peer_id));
-    }
-
-    pub(crate) fn insert(&mut self, peer_id: PeerId, height: Height) {
-        self.map.insert(peer_id, height);
-    }
-
-    pub(crate) fn increment(&mut self, peer_id: PeerId) {
-        if let Some(height) = self.map.get_mut(&peer_id) {
-            *height = height.saturating_add(1);
-        }
-    }
-}
-
 // Attributes of a height in the Bitcoin blockchain.
 trait HeightExt: Clone + Copy + std::hash::Hash + PartialEq + Eq + PartialOrd + Ord {
     fn increment(&self) -> Self;
@@ -404,33 +371,6 @@ pub(crate) fn block_subsidy(height: u32) -> Amount {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn test_height_monitor() {
-        let peer_one = 1.into();
-        let peer_two = 2.into();
-        let peer_three = 3.into();
-
-        let mut height_monitor = HeightMonitor::new();
-        height_monitor.insert(peer_one, 10);
-        assert!(height_monitor.max().unwrap().eq(&10));
-        height_monitor.insert(peer_two, 11);
-        height_monitor.insert(peer_three, 12);
-        assert!(height_monitor.max().unwrap().eq(&12));
-        // this should remove peer three
-        height_monitor.retain(&[peer_one, peer_two]);
-        assert!(height_monitor.max().unwrap().eq(&11));
-        height_monitor.retain(&[]);
-        assert!(height_monitor.max().is_none());
-        height_monitor.insert(peer_one, 10);
-        assert!(height_monitor.max().unwrap().eq(&10));
-        height_monitor.insert(peer_two, 11);
-        // peer one is now at 11
-        height_monitor.increment(peer_one);
-        // peer one is now at 12
-        height_monitor.increment(peer_one);
-        assert!(height_monitor.max().unwrap().eq(&12));
-    }
 
     #[test]
     fn test_subsidy_calculation() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -326,7 +326,7 @@ impl From<SocketAddr> for Socks5Proxy {
     }
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum NodeState {
     // We are behind on block headers according to our peers.
     Behind,

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -448,7 +448,6 @@ pub(crate) enum PeerMessage {
     FilterHeaders(CFHeaders),
     Filter(CFilter),
     Block(Block),
-    NewBlocks(Vec<BlockHash>),
     FeeFilter(FeeRate),
 }
 

--- a/src/network/peer.rs
+++ b/src/network/peer.rs
@@ -259,15 +259,6 @@ impl Peer {
                     .await?;
                 Ok(())
             }
-            ReaderMessage::NewBlocks(block_hashes) => {
-                self.main_thread_sender
-                    .send(PeerThreadMessage {
-                        nonce: self.nonce,
-                        message: PeerMessage::NewBlocks(block_hashes),
-                    })
-                    .await?;
-                Ok(())
-            }
             ReaderMessage::TxRequests(requests) => {
                 let mut tx_queue = self.tx_queue.lock().await;
                 for wtxid in requests {

--- a/src/network/peer_map.rs
+++ b/src/network/peer_map.rs
@@ -22,7 +22,6 @@ use tokio::{
 
 use crate::{
     broadcaster::BroadcastQueue,
-    chain::HeightMonitor,
     default_port_from_network,
     network::{dns::bootstrap_dns, error::PeerError, peer::Peer, PeerId, PeerTimeoutConfig},
     BlockType, Dialog, TrustedPeer,
@@ -50,7 +49,6 @@ pub(crate) struct PeerMap {
     pub(crate) tx_queue: Arc<Mutex<BroadcastQueue>>,
     pub(crate) whitelist_only: bool,
     current_id: PeerId,
-    heights: Arc<Mutex<HeightMonitor>>,
     network: Network,
     block_type: BlockType,
     mtx: Sender<PeerThreadMessage>,
@@ -73,13 +71,11 @@ impl PeerMap {
         dialog: Arc<Dialog>,
         connection_type: ConnectionType,
         timeout_config: PeerTimeoutConfig,
-        height_monitor: Arc<Mutex<HeightMonitor>>,
     ) -> Self {
         Self {
             tx_queue: Arc::new(Mutex::new(BroadcastQueue::new())),
             whitelist_only,
             current_id: PeerId(0),
-            heights: height_monitor,
             network,
             block_type,
             mtx,
@@ -95,9 +91,6 @@ impl PeerMap {
     // Remove any finished connections
     pub async fn clean(&mut self) {
         self.map.retain(|_, peer| !peer.handle.is_finished());
-        let active = self.map.keys().copied().collect::<Vec<PeerId>>();
-        let mut height_lock = self.heights.lock().await;
-        height_lock.retain(&active);
     }
 
     // The number of peers with live connections
@@ -174,18 +167,6 @@ impl PeerMap {
         if let Some(peer) = self.map.get_mut(&nonce) {
             peer.record.update_service_flags(flags);
         }
-    }
-
-    // Set the height of a peer upon receiving the version message
-    pub async fn set_height(&mut self, nonce: PeerId, height: u32) {
-        let mut height_lock = self.heights.lock().await;
-        height_lock.insert(nonce, height);
-    }
-
-    // Add one to the height of a peer when receiving inventory
-    pub async fn increment_height(&mut self, nonce: PeerId) {
-        let mut height_lock = self.heights.lock().await;
-        height_lock.increment(nonce);
     }
 
     // The minimum fee rate to successfully broadcast a transaction to all peers

--- a/src/network/reader.rs
+++ b/src/network/reader.rs
@@ -9,7 +9,7 @@ use bitcoin::{
         message_network::VersionMessage,
         ServiceFlags,
     },
-    Block, BlockHash,
+    Block,
 };
 use bitcoin::{FeeRate, Wtxid};
 use tokio::io::AsyncBufReadExt;
@@ -59,20 +59,7 @@ impl<R: AsyncBufReadExt + Send + Sync + Unpin> Reader<R> {
                 if inventory.len() > MAX_INV {
                     return Some(ReaderMessage::Disconnect);
                 }
-                let mut hashes = Vec::new();
-                for i in inventory {
-                    match i {
-                        Inventory::Block(hash) => hashes.push(hash),
-                        Inventory::CompactBlock(hash) => hashes.push(hash),
-                        Inventory::WitnessBlock(hash) => hashes.push(hash),
-                        _ => continue,
-                    }
-                }
-                if !hashes.is_empty() {
-                    Some(ReaderMessage::NewBlocks(hashes))
-                } else {
-                    None
-                }
+                None
             }
             NetworkMessage::GetData(inventory) => {
                 let mut requests = Vec::new();
@@ -168,7 +155,6 @@ pub(in crate::network) enum ReaderMessage {
     FilterHeaders(CFHeaders),
     Filter(CFilter),
     Block(Block),
-    NewBlocks(Vec<BlockHash>),
     Reject(RejectPayload),
     Disconnect,
     Verack,

--- a/src/node.rs
+++ b/src/node.rs
@@ -16,10 +16,7 @@ use tokio::{
     sync::mpsc::{self},
 };
 use tokio::{
-    sync::{
-        mpsc::{Receiver, UnboundedReceiver},
-        Mutex,
-    },
+    sync::mpsc::{Receiver, UnboundedReceiver},
     time::MissedTickBehavior,
 };
 
@@ -28,7 +25,7 @@ use crate::{
         block_queue::{BlockQueue, ProcessBlockResponse},
         chain::Chain,
         checkpoints::HeaderCheckpoint,
-        CFHeaderChanges, ChainState, FilterCheck, HeaderSyncEffect, HeightMonitor, IndexedHeader,
+        CFHeaderChanges, ChainState, FilterCheck, HeaderSyncEffect, IndexedHeader,
     },
     error::FetchBlockError,
     messages::ClientRequest,
@@ -89,7 +86,6 @@ impl Node {
         let state = NodeState::Behind;
         // Configure the peer manager
         let (mtx, mrx) = mpsc::channel::<PeerThreadMessage>(32);
-        let height_monitor = Arc::new(Mutex::new(HeightMonitor::new()));
         let peer_map = PeerMap::new(
             mtx,
             network,
@@ -99,7 +95,6 @@ impl Node {
             Arc::clone(&dialog),
             connection_type,
             peer_timeout_config,
-            Arc::clone(&height_monitor),
         );
         // Build the chain
         let chain_state = chain_state.unwrap_or(ChainState::Checkpoint(
@@ -109,7 +104,6 @@ impl Node {
             network,
             chain_state,
             Arc::clone(&dialog),
-            height_monitor,
             required_peers,
             filter_type,
         );
@@ -157,7 +151,6 @@ impl Node {
                             match peer_thread.message {
                                 PeerMessage::Version(version) => {
                                     self.peer_map.set_services(peer_thread.nonce, version.services);
-                                    self.peer_map.set_height(peer_thread.nonce, version.start_height as u32).await;
                                     let response = self.handle_version(peer_thread.nonce, version).await?;
                                     self.peer_map.send_message(peer_thread.nonce, response).await;
                                     crate::debug!(format!("[{}]: version", peer_thread.nonce));
@@ -195,15 +188,6 @@ impl Node {
                                     }
                                     None => continue,
                                 },
-                                PeerMessage::NewBlocks(blocks) => {
-                                    crate::debug!(format!("[{}]: inv", peer_thread.nonce));
-                                    match self.handle_inventory_blocks(peer_thread.nonce, blocks).await {
-                                        Some(response) => {
-                                            self.peer_map.broadcast(response).await;
-                                        }
-                                        None => continue,
-                                    }
-                                }
                                 PeerMessage::FeeFilter(feerate) => {
                                     self.peer_map.set_broadcast_min(peer_thread.nonce, feerate);
                                 }
@@ -335,11 +319,8 @@ impl Node {
     // Try to continue with the syncing process
     async fn advance_state(&mut self, last_block: &mut LastBlockMonitor) {
         match self.state {
-            NodeState::Behind => {
-                if self.chain.is_synced().await {
-                    self.state = NodeState::HeadersSynced;
-                }
-            }
+            // This state is updated upon receiving new block headers
+            NodeState::Behind => (),
             NodeState::HeadersSynced => {
                 if self.chain.is_cf_headers_synced() {
                     self.state = NodeState::FilterHeadersSynced;
@@ -380,7 +361,7 @@ impl Node {
     // After we receiving some chain-syncing message, we decide what chain of data needs to be
     // requested next.
     async fn next_stateful_message(&mut self) -> Option<MainThreadMessage> {
-        if !self.chain.is_synced().await {
+        if self.state == NodeState::Behind {
             let headers = GetHeadersMessage {
                 version: WTXID_VERSION,
                 locator_hashes: self.chain.header_chain.locators(),
@@ -431,6 +412,9 @@ impl Node {
         self.peer_map
             .send_message(nonce, MainThreadMessage::Verack)
             .await;
+        self.peer_map
+            .send_message(nonce, MainThreadMessage::SendHeaders)
+            .await;
         // Request peer addresses unless restricted to the whitelist only.
         if !self.peer_map.whitelist_only {
             crate::debug!("Requesting new addresses");
@@ -460,13 +444,21 @@ impl Node {
         let chain = &mut self.chain;
         match chain.sync_chain(headers) {
             Ok(effect) => match effect {
-                HeaderSyncEffect::Added => self.chain.send_chain_update().await,
+                HeaderSyncEffect::Added => {
+                    if self.state != NodeState::Behind {
+                        self.state = NodeState::Behind;
+                    }
+                    self.chain.send_chain_update().await;
+                }
                 HeaderSyncEffect::Empty => {
-                    if !chain.is_synced().await {
-                        return Some(MainThreadMessage::Disconnect);
+                    if self.state == NodeState::Behind {
+                        self.state = NodeState::HeadersSynced;
                     }
                 }
                 HeaderSyncEffect::Reorg(reorgs) => {
+                    if self.state != NodeState::HeadersSynced {
+                        self.state = NodeState::HeadersSynced;
+                    }
                     self.chain.send_chain_update().await;
                     self.block_queue.remove(&reorgs);
                 }
@@ -597,39 +589,6 @@ impl Node {
             return next_block_hash.map(MainThreadMessage::GetBlock);
         }
         None
-    }
-
-    // If new inventory came in, we need to download the headers and update the node state
-    async fn handle_inventory_blocks(
-        &mut self,
-        nonce: PeerId,
-        blocks: Vec<BlockHash>,
-    ) -> Option<MainThreadMessage> {
-        for block in blocks.iter() {
-            if !self.chain.header_chain.contains(*block) {
-                self.peer_map.increment_height(nonce).await;
-                crate::debug!(format!("New block: {}", block));
-            }
-        }
-        match self.state {
-            NodeState::Behind => None,
-            _ => {
-                if blocks
-                    .into_iter()
-                    .any(|block| !self.chain.header_chain.contains(block))
-                {
-                    self.state = NodeState::Behind;
-                    let next_headers = GetHeadersMessage {
-                        version: WTXID_VERSION,
-                        locator_hashes: self.chain.header_chain.locators(),
-                        stop_hash: BlockHash::all_zeros(),
-                    };
-                    Some(MainThreadMessage::GetHeaders(next_headers))
-                } else {
-                    None
-                }
-            }
-        }
     }
 
     // Clear the filter hash cache and redownload the filters.


### PR DESCRIPTION
Closes #331 

BIP-130 allows block announcements by `headers` rather than an `inv` message. This is a logic change to request headers until the peer(s) have no more available, rather than account for the height of the peer(s) chains. BIP-130 is useful because: 1. advertised chain heights by peers cannot be trusted 2. it omits a message roundtrip.

Code changes include:
- State is now adjusted depending on the result of syncing block headers
- The `HeightMonitor` may be completely removed
- `inv` messages do not currently need to be handled