### PR TITLE
Revert `bitcoin` update back to `0.32.8` and release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ Notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.6.2
+
+## Changed
+
+- Unpin `bitcoin` from `0.32.8`
+
 ## 0.6.1
 
 ## Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ rust-version = "1.84.0"
 
 [dependencies]
 addrman = { package = "bitcoin-address-book", version = "0.1.1" }
-bitcoin = { version = "0.32.102", default-features = false, features = [
+bitcoin = { version = "0.32.8", default-features = false, features = [
     "rand-std",
 ] }
 bip324 = { version = "0.7.0", default-features = false, features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bip157"
-version = "0.6.1"
+version = "0.6.2"
 authors = ["Rob <rob@2140.dev>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -40,7 +40,7 @@ pub(crate) mod reader;
 pub(crate) mod socks;
 
 pub const PROTOCOL_VERSION: u32 = 70016;
-pub const KYOTO_VERSION: &str = "0.6.1";
+pub const KYOTO_VERSION: &str = "0.6.2";
 pub const RUST_BITCOIN_VERSION: &str = "0.32.8";
 
 const THIRTY_MINS: Duration = Duration::from_secs(60 * 30);


### PR DESCRIPTION
Closes #593 