### PR TITLE
fix: Avoid potential deadlock by dropping info messages

### DIFF
--- a/src/chain/chain.rs
+++ b/src/chain/chain.rs
@@ -396,15 +396,13 @@ impl Chain {
         self.header_chain.reset_all_filters();
     }
 
-    pub(crate) async fn send_chain_update(&self) {
-        self.dialog
-            .send_info(Info::Progress(Progress::new(
-                self.header_chain.total_filter_headers_synced(),
-                self.header_chain.total_filters_synced(),
-                self.header_chain.internal_chain_len() as u32,
-                self.header_chain.height(),
-            )))
-            .await;
+    pub(crate) fn send_chain_update(&self) {
+        self.dialog.send_info(Info::Progress(Progress::new(
+            self.header_chain.total_filter_headers_synced(),
+            self.header_chain.total_filters_synced(),
+            self.header_chain.internal_chain_len() as u32,
+            self.header_chain.height(),
+        )));
         crate::debug!(format!(
             "Headers: {} CFHeaders: ({}/{}) CFilters: ({}/{})",
             self.header_chain.height(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -456,8 +456,8 @@ impl Dialog {
         let _ = self.warn_tx.send(warning);
     }
 
-    async fn send_info(&self, info: Info) {
-        let _ = self.info_tx.send(info).await;
+    fn send_info(&self, info: Info) {
+        let _ = self.info_tx.try_send(info);
     }
 
     fn send_event(&self, message: Event) {

--- a/src/network/peer.rs
+++ b/src/network/peer.rs
@@ -316,7 +316,7 @@ impl Peer {
                 }
                 self.message_state.verack.got_ack();
                 if self.message_state.verack.both_acks() {
-                    self.dialog.send_info(Info::SuccessfulHandshake).await;
+                    self.dialog.send_info(Info::SuccessfulHandshake);
                     self.message_state.finish_version_handshake();
                 }
                 Ok(())
@@ -423,7 +423,7 @@ impl Peer {
                 self.write_bytes(writer, message).await?;
                 self.message_state.verack.sent_ack();
                 if self.message_state.verack.both_acks() {
-                    self.dialog.send_info(Info::SuccessfulHandshake).await;
+                    self.dialog.send_info(Info::SuccessfulHandshake);
                     self.message_state.finish_version_handshake();
                 }
                 // Take any pending announcements and share them now that the handshake is over

--- a/src/node.rs
+++ b/src/node.rs
@@ -441,7 +441,7 @@ impl Node {
         }
         // Inform the user we are connected to all required peers
         if self.peer_map.live().eq(&self.required_peers) {
-            self.dialog.send_info(Info::ConnectionsMet).await;
+            self.dialog.send_info(Info::ConnectionsMet);
         }
         // Even if we start the node as caught up in terms of height, we need to check for reorgs. So we can send this unconditionally.
         let next_headers = GetHeadersMessage {
@@ -465,7 +465,7 @@ impl Node {
                     if self.state != NodeState::Behind {
                         self.state = NodeState::Behind;
                     }
-                    self.chain.send_chain_update().await;
+                    self.chain.send_chain_update();
                 }
                 HeaderSyncEffect::Empty => {
                     if self.state == NodeState::Behind {
@@ -476,7 +476,7 @@ impl Node {
                     if self.state != NodeState::HeadersSynced {
                         self.state = NodeState::HeadersSynced;
                     }
-                    self.chain.send_chain_update().await;
+                    self.chain.send_chain_update();
                     self.block_queue.remove(&reorgs);
                 }
             },
@@ -497,7 +497,7 @@ impl Node {
         peer_id: PeerId,
         cf_headers: CFHeaders,
     ) -> Option<MainThreadMessage> {
-        self.chain.send_chain_update().await;
+        self.chain.send_chain_update();
         match self.chain.sync_cf_headers(peer_id, cf_headers) {
             Ok(potential_message) => match potential_message {
                 CFHeaderChanges::AddedToQueue => None,
@@ -529,7 +529,7 @@ impl Node {
             Ok(potential_message) => {
                 let FilterCheck { was_last_in_batch } = potential_message;
                 if was_last_in_batch {
-                    self.chain.send_chain_update().await;
+                    self.chain.send_chain_update();
                     if !self.chain.is_filters_synced() {
                         let next_filters = self.chain.next_filter_message();
                         return Some(MainThreadMessage::GetFilters(next_filters));
@@ -571,8 +571,7 @@ impl Node {
         match process_block_response {
             ProcessBlockResponse::Accepted { block_recipient } => {
                 self.dialog
-                    .send_info(Info::BlockReceived(block.block_hash()))
-                    .await;
+                    .send_info(Info::BlockReceived(block.block_hash()));
                 let send_err = block_recipient
                     .send(Ok(IndexedBlock::new(height, block)))
                     .is_err();


### PR DESCRIPTION
Closes #597. Before this would halt the node if the client was not polling the info channel and the number of info messages reached the channel size. It is valid for a client to leave the info channel unused, so this behavior should be changed to a best effort send.