### PR TITLE
Remove stale `data_dir` configuration

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,4 +1,4 @@
-use std::{path::PathBuf, time::Duration};
+use std::time::Duration;
 
 use bitcoin::Network;
 
@@ -65,13 +65,6 @@ impl Builder {
     /// Add a preferred peer to try to connect to.
     pub fn add_peer(mut self, trusted_peer: impl Into<TrustedPeer>) -> Self {
         self.config.white_list.push(trusted_peer.into());
-        self
-    }
-
-    /// Add a path to the directory where data should be stored. If none is provided, the current
-    /// working directory will be used.
-    pub fn data_dir(mut self, path: impl Into<PathBuf>) -> Self {
-        self.config.data_path = Some(path.into());
         self
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,7 +64,6 @@ use bitcoin::OutPoint;
 use chain::Filter;
 
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
-use std::path::PathBuf;
 
 // Re-exports
 #[doc(inline)]
@@ -377,7 +376,6 @@ struct Config {
     required_peers: u8,
     white_list: Vec<TrustedPeer>,
     whitelist_only: bool,
-    data_path: Option<PathBuf>,
     chain_state: Option<ChainState>,
     connection_type: ConnectionType,
     peer_timeout_config: PeerTimeoutConfig,
@@ -391,7 +389,6 @@ impl Default for Config {
             required_peers: 1,
             white_list: Default::default(),
             whitelist_only: Default::default(),
-            data_path: Default::default(),
             chain_state: Default::default(),
             connection_type: Default::default(),
             peer_timeout_config: PeerTimeoutConfig::default(),

--- a/src/node.rs
+++ b/src/node.rs
@@ -67,7 +67,6 @@ impl Node {
             required_peers,
             white_list,
             whitelist_only,
-            data_path: _,
             chain_state,
             connection_type,
             peer_timeout_config,

--- a/tests/core.rs
+++ b/tests/core.rs
@@ -55,7 +55,7 @@ fn start_bitcoind(with_v2_transport: bool) -> anyhow::Result<(corepc_node::Node,
 
 fn new_node(
     socket_addr: SocketAddrV4,
-    tempdir_path: PathBuf,
+    _tempdir_path: PathBuf,
     chain_state: ChainState,
 ) -> (Node, Client) {
     let host = (IpAddr::V4(*socket_addr.ip()), Some(socket_addr.port()));
@@ -63,7 +63,7 @@ fn new_node(
     trusted.set_services(ServiceFlags::P2P_V2);
     let builder = bip157::builder::Builder::new(bitcoin::Network::Regtest);
     let builder = builder.chain_state(chain_state);
-    let (node, client) = builder.add_peer(host).data_dir(tempdir_path).build();
+    let (node, client) = builder.add_peer(host).build();
     (node, client)
 }
 
@@ -671,7 +671,6 @@ async fn whitelist_only_sync() {
     setup_debug_output();
     let (bitcoind, socket_addr) = start_bitcoind(true).unwrap();
     let rpc = &bitcoind.client;
-    let tempdir = tempfile::TempDir::new().unwrap().path().to_owned();
     let miner = rpc.new_address().unwrap();
     mine_blocks(rpc, &miner, 10, 2).await;
     let best = best_hash(rpc);
@@ -681,8 +680,7 @@ async fn whitelist_only_sync() {
             bitcoin::Network::Regtest,
         )))
         .add_peer(host)
-        .whitelist_only()
-        .data_dir(&tempdir);
+        .whitelist_only();
     let (node, client) = builder.build();
     tokio::task::spawn(async move { node.run().await });
     let Client {
@@ -702,8 +700,7 @@ async fn whitelist_only_sync() {
         .chain_state(ChainState::Checkpoint(HashCheckpoint::from_genesis(
             bitcoin::Network::Regtest,
         )))
-        .whitelist_only()
-        .data_dir(&tempdir);
+        .whitelist_only();
     let (node, _client) = builder.build();
     let result = node.run().await;
     assert!(result.is_err());
@@ -719,8 +716,7 @@ async fn whitelist_only_sync() {
             bitcoin::Network::Regtest,
         )))
         .add_peer(peer)
-        .whitelist_only()
-        .data_dir(&tempdir);
+        .whitelist_only();
     let (node, client) = builder.build();
     tokio::task::spawn(async move { node.run().await });
     let Client {


### PR DESCRIPTION
Closes #600

This used to be a multi-purpose directory that would store both the header chain and peers, but the decision to remove `rusqlite` also removed header storage. Peer storage has not been re-implemented, and will probably not be implemented unless there is a demand for such a feature. For the time being, I am keeping `tempdir` in case peer persistence is implemented in the near future.